### PR TITLE
change the version # to 3.2.0

### DIFF
--- a/repository/Seaside-Core.package/GRPlatform.extension/instance/seasideVersion.st
+++ b/repository/Seaside-Core.package/GRPlatform.extension/instance/seasideVersion.st
@@ -2,5 +2,5 @@
 seasideVersion
 	"Answer the Seaside version"
 
-	^ (GRVersion major: 3 minor: 1 revision: 2)
+	^ (GRVersion major: 3 minor: 2 revision: 0)
 		yourself


### PR DESCRIPTION
The version of #seasideVersion on Smalltalk hub is correct, but not here in github.  Not sure if this is the only difference between the two repos or not. 