### PR TITLE
Do not run Pharo 4 with default config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ smalltalk:
   - Pharo-6.1
   - Pharo-6.0
   - Pharo-5.0
-  - Pharo-4.0
   - Squeak-trunk
   - Squeak-5.1
 


### PR DESCRIPTION
Do not run Pharo 4 with default config, it is included explicitly with a custom configuration.