### PR TITLE
1102-Remove-duplication-between-squeak-and-pharo-in-baseline-security

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinesecurity..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinesecurity..st
@@ -1,33 +1,21 @@
 baselines
 baselinesecurity: spec
 	spec
-		for: #pharo
-		do: [ spec package: 'Cryptography' with: [ spec repository: 'github://pharo-contributions/Cryptography:0.3.2/source' ].
-			spec
-				package: 'Seaside-Security'
-					with: [ spec
-						requires: #('Seaside-Core' 'Cryptography');
-						includes: #('Seaside-Pharo-Security') ];
-				package: 'Seaside-Pharo-Security';
-				package: 'Seaside-Tests-Security' with: [ spec requires: #('Seaside-Security') ].
-			spec
-				package: 'Seaside-Tests-Security' with: [ spec includes: #('Seaside-Tests-Pharo-Security') ];
-				package: 'Seaside-Tests-Pharo-Security' ].
-	spec
-		for: #squeak
-		do: [ spec package: 'Cryptography' with: [ spec repository: 'http://www.squeaksource.com/Cryptography' ].
-			spec
-				package: 'Seaside-Security'
-					with: [ spec
-						requires: #('Seaside-Core' 'Cryptography');
-						includes: #('Seaside-Pharo-Security') ];
-				package: 'Seaside-Pharo-Security';
-				package: 'Seaside-Tests-Security' with: [ spec requires: #('Seaside-Security') ].
-			spec
-				package: 'Seaside-Tests-Security' with: [ spec includes: #('Seaside-Tests-Pharo-Security') ];
-				package: 'Seaside-Tests-Pharo-Security' ].
-	spec
 		for: #squeakCommon
 		do: [ spec
+				package: 'Seaside-Security'
+					with: [ spec
+						requires: #('Seaside-Core' 'Cryptography');
+						includes: #('Seaside-Pharo-Security') ];
+				package: 'Seaside-Pharo-Security';
+				package: 'Seaside-Tests-Security' with: [ spec requires: #('Seaside-Security') ];
+				package: 'Seaside-Tests-Security' with: [ spec includes: #('Seaside-Tests-Pharo-Security') ];
+				package: 'Seaside-Tests-Pharo-Security'.
+
+			spec
 				group: 'Security' with: #('Seaside-Security');
-				group: 'Security Tests' with: #('Seaside-Tests-Security') ]
+				group: 'Security Tests' with: #('Seaside-Tests-Security') ].
+
+	spec for: #pharo do: [ spec package: 'Cryptography' with: [ spec repository: 'github://pharo-contributions/Cryptography:0.3.2/source' ] ].
+
+	spec for: #squeak do: [ spec package: 'Cryptography' with: [ spec repository: 'http://www.squeaksource.com/Cryptography' ] ]


### PR DESCRIPTION
Remove duplication in baseline security.

Fixes #1102