### PR TITLE
avoid_undeclared_in_logs

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/startWelcomeSeasideAdaptorInPharo.st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/startWelcomeSeasideAdaptorInPharo.st
@@ -1,5 +1,5 @@
 doits
 startWelcomeSeasideAdaptorInPharo
-	WAAdmin defaultServerManager adaptors
+	(Smalltalk globals at: #WAAdmin) defaultServerManager adaptors
 		ifEmpty: [ (Smalltalk globals includesKey: #ZnZincServerAdaptor)
 				ifTrue: [ (Smalltalk globals at: #ZnZincServerAdaptor) startOn: 8080 ] ]

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/startWelcomeSeasideAdaptorInSqueak.st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/startWelcomeSeasideAdaptorInSqueak.st
@@ -1,6 +1,6 @@
 doits
 startWelcomeSeasideAdaptorInSqueak
-	WAAdmin defaultServerManager adaptors
+	(Smalltalk globals at: #WAAdmin) defaultServerManager adaptors
 		ifEmpty: [ (Smalltalk globals includesKey: #WAWebServerAdaptor)
 				ifTrue: [ ((Smalltalk globals at: #WAWebServerAdaptor) port: 8080)
 						codec: ((Smalltalk globals at: #GRCodec) forEncoding: 'utf-8');


### PR DESCRIPTION
Do not reference classes that are not loaded directly in the baseline to avoid undefined.Because then you cannot change the method if you only load the baseline to work on it and you'll get undeclared in the logs.