### PR TITLE
Issue #88: add 3.5.0 to baseline ... local tests are passing

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinegemstone..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinegemstone..st
@@ -97,7 +97,7 @@ baselinegemstone: spec
         package: 'Seaside-GemStone-Core'
           with: [ spec requires: #('Seaside-GemStone300-Core') ] ].
   spec
-    for: #(#'gs3.2.x' #'gs3.3.x' #'gs3.4.x')
+    for: #(#'gs3.2.x' #'gs3.3.x' #'gs3.4.x' #'gs3.5.x' #'gs3.6.x')
     do: [ 
       spec
         package: 'Seaside-Core'


### PR DESCRIPTION
[All of the GemStone tests passed](https://travis-ci.org/SeasideSt/Seaside/builds/490810666) and the only changes I've made is to the `baselineGemstone` method .. all of the Pharo builds failed `WANoDuplicateUuidsTest` so this must be a pharo thing ... I will go ahead a merge when travis is done, since I am hoping to use this for internal test runs before 3.5.0 is released ...