### PR TITLE
Remove code duplication and fix remoteaddress-based tracking strategy and filter

### DIFF
--- a/repository/Seaside-Core.package/WARemoteAddressProtectionFilter.class/instance/remoteAddressFromRequest..st
+++ b/repository/Seaside-Core.package/WARemoteAddressProtectionFilter.class/instance/remoteAddressFromRequest..st
@@ -1,11 +1,6 @@
 private
 remoteAddressFromRequest: aRequest
-	remoteAddress ifNil: [
-		remoteAddress := aRequest
-			headerAt: 'x-forwarded-for'
-			ifAbsent: [
-				aRequest
-					headerAt: 'forwarded-for'
-					ifAbsent: [
-						aRequest remoteAddress ] ] ].
-	^ aRequest remoteAddress
+	| result |
+	result := aRequest forwarded ifNil:[ aRequest remoteAddress ].
+	remoteAddress ifNil:[ remoteAddress := result ].
+	^ result

--- a/repository/Seaside-Core.package/WARemoteAddressProtectionFilter.class/instance/remoteAddressFromRequest..st
+++ b/repository/Seaside-Core.package/WARemoteAddressProtectionFilter.class/instance/remoteAddressFromRequest..st
@@ -1,6 +1,6 @@
 private
 remoteAddressFromRequest: aRequest
 	| result |
-	result := aRequest forwarded ifNil:[ aRequest remoteAddress ].
+	result := aRequest forwardedFor ifNil:[ aRequest remoteAddress ].
 	remoteAddress ifNil:[ remoteAddress := result ].
 	^ result

--- a/repository/Seaside-Core.package/WARequest.class/instance/forwarded.st
+++ b/repository/Seaside-Core.package/WARequest.class/instance/forwarded.st
@@ -1,0 +1,3 @@
+accessing-headers
+forwarded
+	^ self headerAt: 'forwarded' ifAbsent:[ self headerAt: 'x-forwarded-for' ]

--- a/repository/Seaside-Core.package/WARequest.class/instance/forwarded.st
+++ b/repository/Seaside-Core.package/WARequest.class/instance/forwarded.st
@@ -1,3 +1,3 @@
 accessing-headers
 forwarded
-	^ self headerAt: 'forwarded' ifAbsent:[ self headerAt: 'x-forwarded-for' ]
+	^ self headerAt: 'forwarded'

--- a/repository/Seaside-Core.package/WARequest.class/instance/forwardedFor.st
+++ b/repository/Seaside-Core.package/WARequest.class/instance/forwardedFor.st
@@ -1,0 +1,13 @@
+accessing
+forwardedFor
+	"Returns the value of the first occurrence of the For directive in a forwarded header, if it exists. Returns nil otherwise."
+	| startOfFirstForDirective endOfFirstForDirective |
+	^ self forwarded ifNotNil:[ :forwarded | 
+		startOfFirstForDirective := forwarded indexOfSubCollection:'for=' startingAt: 1.
+		startOfFirstForDirective = 0 ifTrue:[ startOfFirstForDirective := forwarded indexOfSubCollection:'For=' startingAt: 1 ].
+		startOfFirstForDirective ~= 0
+			ifTrue:[ 
+				endOfFirstForDirective := (forwarded indexOfAnyOf: ';,' startingAt: startOfFirstForDirective) - 1.
+				endOfFirstForDirective = -1 ifTrue:[ endOfFirstForDirective := forwarded size ].
+				forwarded copyFrom: startOfFirstForDirective + 4 to: endOfFirstForDirective ]
+			ifFalse: [ nil ] ]

--- a/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/remoteAddressFromRequest..st
+++ b/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/remoteAddressFromRequest..st
@@ -1,8 +1,0 @@
-private
-remoteAddressFromRequest: aRequest
-	^ aRequest
-			headerAt: 'x-forwarded-for'
-			ifAbsent: [
-				aRequest
-					headerAt: 'forwarded-for'
-					ifAbsent: [ aRequest remoteAddress ] ]

--- a/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/sessionIdFromContext..st
+++ b/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/sessionIdFromContext..st
@@ -1,3 +1,3 @@
 private
 sessionIdFromContext: aRequestContext
-	^ self remoteAddressFromRequest: aRequestContext request
+	^ aRequestContext request forwarded ifNil:[ aRequestContext request remoteAddress ]

--- a/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/sessionIdFromContext..st
+++ b/repository/Seaside-Session.package/WAIPSessionTrackingStrategy.class/instance/sessionIdFromContext..st
@@ -1,3 +1,3 @@
 private
 sessionIdFromContext: aRequestContext
-	^ aRequestContext request forwarded ifNil:[ aRequestContext request remoteAddress ]
+	^ aRequestContext request forwardedFor ifNil:[ aRequestContext request remoteAddress ]

--- a/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testForwarded.st
+++ b/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testForwarded.st
@@ -1,0 +1,9 @@
+tests
+testForwarded
+	| request headers |
+	request := WARequest method: 'GET' uri: '/foo?bar=1'.
+	headers := Dictionary new.
+	headers at: 'forwarded' put: 'For="[2001:db8:cafe::17]:4711"'.
+	request setHeaders: headers.
+	
+	self assert: request forwarded = 'For="[2001:db8:cafe::17]:4711"'

--- a/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testForwardedFor.st
+++ b/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testForwardedFor.st
@@ -1,0 +1,13 @@
+tests
+testForwardedFor
+	| request headers |
+	request := WARequest method: 'GET' uri: '/foo?bar=1'.
+	headers := Dictionary new.
+	request setHeaders: headers.
+	
+	headers at: 'forwarded' put: 'For="[2001:db8:cafe::17]:4711"'.
+	self assert: request forwardedFor equals: '"[2001:db8:cafe::17]:4711"'.
+	headers at: 'forwarded' put: 'for=192.0.2.60;proto=http;by=203.0.113.43'.
+	self assert: request forwardedFor equals: '192.0.2.60'.
+	headers at: 'forwarded' put: 'for=192.0.2.43, for=198.51.100.17'.
+	self assert: request forwardedFor equals: '192.0.2.43'


### PR DESCRIPTION
Remove code duplication and fix for retrieving value in forwarded header -or- the remoteAddress when relying on the origin ip in the `WARemoteAddressProtectionFilter` and `WAIPSessionTrackingStrategy`

In addition, the`WARemoteAddressProtectionFilter` was storing the value from the forwarded header (if present) but the first comparison was still returning the remoteAddress anyway. So this can never have worked in the case where using the header was necessary.

Fixes for 1152