### PR TITLE
Revert allowing Squeak 5.2 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ aliases:
 matrix:
   allow_failures:
     - smalltalk: Squeak-trunk
-    - smalltalk: Squeak-5.2
     - smalltalk: Squeak-5.1
   
   include:


### PR DESCRIPTION
My previous commit was not good. We already test on Squeak 5.2,
the tests are green and it is even in the badges.