### PR TITLE
Add dynamic mime document in tests

### DIFF
--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/README.md
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/README.md
@@ -1,0 +1,13 @@
+I am a MIME document whos contents are generated dynamically by a block.
+
+I can be used like this:
+
+html image
+	document: (WABlockMimeDocument onBlock: [ self generateSvg ])
+	mimeType: (WAMimeType main: 'image' sub: 'svg+xml')
+
+Instance Variables
+	block:		<aNiladicBlock>
+
+block
+	- the block that generates the contents, either a String or ByteArray

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/class/onBlock..st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/class/onBlock..st
@@ -1,0 +1,3 @@
+instance creation
+onBlock: aNiladicBlock
+	^ self basicNew initializeOnBlock: aNiladicBlock

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/contents..st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/contents..st
@@ -1,0 +1,3 @@
+accessing
+contents: aCollection
+	self shouldNotImplement

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/contents.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/contents.st
@@ -1,0 +1,3 @@
+accessing
+contents
+	^ block value

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/initializeOnBlock..st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/initializeOnBlock..st
@@ -1,0 +1,6 @@
+initialization
+initializeOnBlock: aNiladicBlock
+	self initialize.
+	self mimeType: nil.
+	self fileName: nil.
+	block := aNiladicBlock

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/seasideMimeDocumentType..st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/instance/seasideMimeDocumentType..st
@@ -1,0 +1,7 @@
+converting
+seasideMimeDocumentType: aMimeType
+	aMimeType = self mimeType
+		ifTrue: [ ^ self ].
+	^ self copy
+		mimeType: aMimeType;
+		yourself

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/properties.json
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocument.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "pmm 10/27/2019 21:28",
+	"super" : "WAMimeDocument",
+	"category" : "Seaside-Tests-Core-HTTP",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"block"
+	],
+	"name" : "WABlockMimeDocument",
+	"type" : "normal"
+}

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentByteArray.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentByteArray.st
@@ -1,0 +1,9 @@
+tests
+testAsMIMEDocumentByteArray
+	| document content |
+	document := WABlockMimeDocument onBlock: [ #(1 2 3 4) asByteArray ].
+	self assert: document contentType = WAMimeType applicationOctetStream.
+	content := document content.
+	self assert: content size = 4.
+	self assert: content class = ByteArray.
+	1 to: 4 do: [ :index | self assert: (content at: index) = index ]

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentByteArrayColon.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentByteArrayColon.st
@@ -1,0 +1,10 @@
+tests
+testAsMIMEDocumentByteArrayColon
+	| document content |
+	document := WABlockMimeDocument onBlock: [ #(1 2 3 4) asByteArray ].
+	document mimeType: WAMimeType imageJpeg.
+	self assert: document contentType = WAMimeType imageJpeg.
+	content := document content.
+	self assert: content size = 4.
+	self assert: content class = ByteArray.
+	1 to: 4 do: [ :index | self assert: (content at: index) = index ]

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentString.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentString.st
@@ -1,0 +1,8 @@
+tests
+testAsMIMEDocumentString
+	| document |
+	document := (WABlockMimeDocument onBlock: [ 'hello Seaside' ])
+		mimeType: WAMimeType textPlain;
+		yourself.
+	self assert: document contentType = WAMimeType textPlain.
+	self assert: document content = 'hello Seaside'

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentStringColon.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testAsMIMEDocumentStringColon.st
@@ -1,0 +1,7 @@
+tests
+testAsMIMEDocumentStringColon
+	| document |
+	document := WABlockMimeDocument onBlock: [ 'hello Seaside' ].
+	document mimeType: 'text/x-weirdo' seasideMimeType.
+	self assert: document contentType = 'text/x-weirdo' seasideMimeType.
+	self assert: document content = 'hello Seaside'

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testByteArraySeasideMimeDocumentType.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testByteArraySeasideMimeDocumentType.st
@@ -1,0 +1,7 @@
+tests
+testByteArraySeasideMimeDocumentType
+	| document mpeg |
+	mpeg := WAMimeType main: 'audio' sub: 'mpeg'.
+	document :=  (WABlockMimeDocument onBlock: [ #(1 2 3 4) asByteArray ]) seasideMimeDocumentType: mpeg.
+	self assert: document mimeType = mpeg.
+	self assert: document contents = #(1 2 3 4) asByteArray 

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testStringSeasideMimeDocumentType.st
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/instance/testStringSeasideMimeDocumentType.st
@@ -1,0 +1,7 @@
+tests
+testStringSeasideMimeDocumentType
+	| document csv |
+	csv := WAMimeType main: 'text' sub: 'csv'.
+	document := (WABlockMimeDocument onBlock: [ 'foo,bar' ]) seasideMimeDocumentType: csv.
+	self assert: document mimeType = csv.
+	self assert: document contents = 'foo,bar'

--- a/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/properties.json
+++ b/repository/Seaside-Tests-Core.package/WABlockMimeDocumentTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Seaside-Tests-Core-HTTP",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WABlockMimeDocumentTest",
+	"type" : "normal"
+}


### PR DESCRIPTION
Add dynamic mime document in tests as an example on how to dynamically generate resources.

Closes #1188