### PR TITLE
Improving WARequestTest >> testPostFields

### DIFF
--- a/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testPostFields.st
+++ b/repository/Seaside-Tests-Core.package/WARequestTest.class/instance/testPostFields.st
@@ -2,10 +2,17 @@ tests
 testPostFields
 	| request headers |
 	request := WARequest method: 'POST' uri: '/foo?bar=1'.
+	self
+		deny: request isXmlHttpRequest;
+		assert: request headers class equals: WAHeaderFields;
+		assert: request remoteAddress isNil;
+		assert: request isPost;
+		assert: request sslSessionId isNil.
 	headers := Dictionary new.
 	headers at: 'content-type' put: WAMimeType formUrlencoded greaseString.
 	request setHeaders: headers.
 	request setBody: 'baz=2&bar=3'.
+	self should: [ request bodyDecoded ] raise: WAIllegalStateException.
 	request setPostFields: (WARequestFields new at: 'baz' put: '2'; at: 'bar' put: '3'; yourself).
 	
 	self assert: request postFields size = 2.


### PR DESCRIPTION
Hi,

I submit this pull request to suggest some improvements in the test method #testPostFields to cover some corner cases in the class WARequest.

By including the lines #5-#10 the test will now execute methods in the class under test which previously were not covered by WARequestTest (isXmlHttpRequest, headers, remoteAddress, isPost, sslSessionId). This will also guard against a WARRequest object which is improperly initialized.
Line #6 verifies that the WARRequest does not have an XMLHttpRequest header by default.
Line #9 on the other hand verifies that WARequest is properly initialized via #method:uri: and ‘POST’ argument.

By including Line #15, the test will guard against sending #bodyDecoded when charSet isNil (a WAMimeType(application/x-www-form-urlencoded) has a nil charSet).


Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.