### PR TITLE
GemStone 3.6 port complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ matrix:
     - smalltalk: Squeak-5.1
       env: BUILD_NAME=Squeak-5.1
     
-    - smalltalk: GemStone-3.5.3
-      env: BUILD_NAME=GemStone-3.5.3
+    - smalltalk: GemStone-3.5.4
+      env: BUILD_NAME=GemStone-3.5.4
       cache:
         directories:
           - $SMALLTALK_CI_CACHE

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   allow_failures:
     - smalltalk: Squeak-trunk
     - smalltalk: Squeak-5.1
+    - smalltalk: Squeak-5.2   ### see https://github.com/SeasideSt/Seaside/issues/1229
     - smalltalk: Pharo64-9.0
   
   include:

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/projectClass.st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/projectClass.st
@@ -1,0 +1,4 @@
+accessing
+projectClass
+  Smalltalk at: #'MetacelloCypressBaselineProject' ifPresent: [ :cl | ^ cl ].
+  ^ super projectClass


### PR DESCRIPTION
fix #1226 and move Squeak-5.2 to allowed failures (#1229).

While the 3.6.0 port did not require any direct changes to the Seaside code itself, a number of other projects were changed in order to get all of the Seaside tests to pass for 3.5.4 and 3.6.0.

@jbrichau, no review required as the changes do not involve the Seaside code base ... other than adding #projectClass to the baseline, to complete the contract for metadataless operation ... 

There was a bug in Metacello/metacello#531 that reared it's head when I added the #projectClass method and that may have been the reason it was not done when the other changes were made, but that bug is fixed.