### PR TITLE
fix https://github.com/SeasideSt/Seaside/issues/1246

### DIFF
--- a/repository/Seaside-GemStone-Core.package/CharacterCollection.extension/instance/seasideMimeDocument.st
+++ b/repository/Seaside-GemStone-Core.package/CharacterCollection.extension/instance/seasideMimeDocument.st
@@ -1,0 +1,3 @@
+*seaside-gemstone-core
+seasideMimeDocument
+	^ WAMimeDocument on: self mimeType: WAMimeType textPlain


### PR DESCRIPTION
Fix #1246 
It add CharacterCollection>>seasideMimeDocument to Seaside-GemstoneCore but does not remove String>>seasideMimeDocument  which is in Seaside-Core.
