### PR TITLE
Changes iteration to use Interval

### DIFF
--- a/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
@@ -2,7 +2,7 @@ rendering
 renderContentOn: html 
 	self renderExplanationOn: html.
 	html unorderedList: [
-		1 to: 5000 do: [ :each | 
+		(1 to: 5000) do: [ :each | 
 			html listItem: [
 				html anchor
 					name: each;

--- a/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
@@ -1,5 +1,8 @@
 rendering
 renderContentOn: html 
+	"Note: we use  ̀(1 to: 5000) do: []̀ instead of (1 to: 500 do: [])
+	to avoid scoping issues in Integer>>#to:do: in other dialects."
+
 	self renderExplanationOn: html.
 	html unorderedList: [
 		(1 to: 5000) do: [ :each | 


### PR DESCRIPTION
The use of `Integer>>#to:do:` to generate the callbacks causes variable references issues in VAST, so to avoid having to patch the method in VAST, we modify it directly upstream with a change that is innocuous to other dialects. 