### PR TITLE
Adapt tests to changes in chromedriver and Parasol

### DIFF
--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/expectedFailures.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/expectedFailures.st
@@ -1,9 +1,7 @@
 running
 expectedFailures
-	| todo temporaryDisabled |
-	"temporarydisabled due to chromedriver bug https://bugs.chromium.org/p/chromium/issues/detail?id=1205107"
-	temporaryDisabled := #(testButtonFunctionalTest testCanvasTagFunctionalTest).
+	| todo |
 	todo := #(testExceptionFunctionalTest testExpiryFunctionalTest testFilterFunctionalTest testFlowErrorFunctionalTest).
-	^ temporaryDisabled, ((GRPlatform current class == (Smalltalk at: #GRGemStonePlatform ifAbsent:[ nil ]))
+	^ ((GRPlatform current class == (Smalltalk at: #GRGemStonePlatform ifAbsent:[ nil ]))
 		ifTrue: [ #(testContextFunctionalTest), todo "requires https://github.com/GsDevKit/Grease/pull/17 to be merged" ]
 		ifFalse:[  todo ])

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testButtonFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testButtonFunctionalTest.st
@@ -11,19 +11,19 @@ testButtonFunctionalTest
 	self assert: (driver findElementByTagName: 'td') getText equals: 'a textAt the Seaside!'.
 
 	"Push reset"
-	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getAttribute:'value') equals: 'a textAt the Seaside!'.
+	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getProperty: 'value') equals: 'a textAt the Seaside!'.
 	(driver findElementByCSSSelector: 'input[type=text]') click.
 	driver getKeyboard sendKeys: 'blabla'.
-	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getAttribute:'value') ~= 'a textAt the Seaside!'.
+	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getProperty: 'value') ~= 'a textAt the Seaside!'.
 	(driver findElementByCSSSelector: 'button[type=reset]') click.
 	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getAttribute:'value') equals: 'a textAt the Seaside!'.
 	
 	"Push push"
 	(driver findElementByCSSSelector: 'input[type=text]') click.
 	driver getKeyboard sendKeys: 'blabla'.
-	inputValue := (driver findElementByCSSSelector: 'input[type=text]') getAttribute:'value'.
+	inputValue := (driver findElementByCSSSelector: 'input[type=text]') getProperty: 'value'.
 	textValue := (driver findElementByTagName: 'td') getText.
 	self assert: (inputValue ~= textValue).
 	(driver findElementByCSSSelector: 'button[type=button]') click.
-	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getAttribute:'value') equals: inputValue.
+	self assert: ((driver findElementByCSSSelector: 'input[type=text]') getProperty: 'value') equals: inputValue.
 	self assert: (driver findElementByTagName: 'td') getText equals: textValue

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCanvasTagFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCanvasTagFunctionalTest.st
@@ -4,4 +4,4 @@ testCanvasTagFunctionalTest
 	self selectTest: 'WACanvasTagTest'.
 	"Can only test if this does not crash"
 	driver findElementByID: #tutorial.
-	self assert: ((driver findElementsByTagName: 'script') anySatisfy: [ :script | (script getAttribute: 'innerHTML') = 'drawShape()' ]).
+	self assert: ((driver findElementsByTagName: 'script') anySatisfy: [ :script | (script getProperty: 'innerHTML') = 'drawShape()' ]).


### PR DESCRIPTION
This fixes some disabled Parasol tests that were broken because of a change in chromedriver (see https://bugs.chromium.org/p/chromium/issues/detail?id=1205107)