### PR TITLE
Adds CORS filter and Functional test

### DIFF
--- a/repository/Seaside-Core.package/WACORSFilter.class/README.md
+++ b/repository/Seaside-Core.package/WACORSFilter.class/README.md
@@ -1,0 +1,1 @@
+Implements a WARequestFilter that adds support to handle CORS requests.

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedMethod..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedMethod..st
@@ -1,0 +1,6 @@
+methods
+addAllowedMethod: httpMethod
+
+	self allowedMethods add: httpMethod
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedMethodsHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedMethodsHeadersTo..st
@@ -1,0 +1,7 @@
+headers
+addAllowedMethodsHeadersTo: aResponse
+
+	self allowedMethods ifNotEmpty: [:allowed |
+		aResponse
+			headerAt: 'Access-Control-Allow-Methods'
+			put: (', ' join: allowed) ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOrigin..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOrigin..st
@@ -1,0 +1,6 @@
+origins
+addAllowedOrigin: originUrlString
+
+	self allowedOrigins add: originUrlString asString
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeadersTo..st
@@ -1,0 +1,9 @@
+headers
+addAllowedOriginHeadersTo: aResponse
+
+	self allowedOrigins ifNotEmpty: [ :allowed | 
+		| allowedOrigin |
+		allowedOrigin := allowed first.
+		aResponse headerAt: 'Access-Control-Allow-Origin' put: allowedOrigin.
+		allowedOrigin = '*' ifFalse: [ 
+			aResponse headerAt: 'Vary' put: 'Origin' ] ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
@@ -1,0 +1,5 @@
+headers
+addCORSHeadersTo: response
+
+	self addAllowedOriginHeadersTo: response.
+	self addAllowedMethodsHeadersTo: response

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addExposedHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addExposedHeadersTo..st
@@ -1,0 +1,7 @@
+headers
+addExposedHeadersTo: aResponse
+
+	self exposedHeaders ifNotEmpty: [ :exposed | 
+		aResponse
+			headerAt: 'Access-Control-Expose-Headers'
+			put: (', ' join: exposed) ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAnyOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAnyOrigin.st
@@ -1,0 +1,6 @@
+origins
+allowAnyOrigin
+
+	self addAllowedOrigin: '*'
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedHeaders..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedHeaders..st
@@ -1,0 +1,4 @@
+accessing
+allowedHeaders: anObject
+
+	allowedHeaders := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedHeaders.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedHeaders.st
@@ -1,0 +1,4 @@
+accessing
+allowedHeaders 
+
+	^allowedHeaders

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedMethods..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedMethods..st
@@ -1,0 +1,4 @@
+accessing
+allowedMethods: anObject
+
+	allowedMethods := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedMethods.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedMethods.st
@@ -1,0 +1,4 @@
+accessing
+allowedMethods 
+
+	^allowedMethods

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins..st
@@ -1,0 +1,4 @@
+accessing
+allowedOrigins: anObject
+
+	allowedOrigins := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins.st
@@ -1,0 +1,4 @@
+accessing
+allowedOrigins 
+
+	^allowedOrigins ifNil: [ allowedOrigins := OrderedCollection new ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsAnyOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsAnyOrigin.st
@@ -1,0 +1,6 @@
+testing
+allowsAnyOrigin
+
+	^self allowedOrigins anySatisfy: [ :origin | origin = '*' ]
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials..st
@@ -1,0 +1,4 @@
+accessing
+allowsCredentials: anObject
+
+	allowsCredentials := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials.st
@@ -1,0 +1,4 @@
+accessing
+allowsCredentials
+
+	^ allowsCredentials

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/denyAllOrigins.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/denyAllOrigins.st
@@ -1,0 +1,6 @@
+origins
+denyAllOrigins
+
+	self allowedOrigins removeAll
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/explicitMethods.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/explicitMethods.st
@@ -1,0 +1,4 @@
+methods
+explicitMethods
+
+	^#('GET' 'POST' 'HEAD')

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders..st
@@ -1,0 +1,4 @@
+accessing
+exposedHeaders: anObject
+
+	exposedHeaders := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders.st
@@ -1,0 +1,4 @@
+accessing
+exposedHeaders 
+
+	^exposedHeaders

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/handleCORSFiltered..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/handleCORSFiltered..st
@@ -1,0 +1,5 @@
+handling
+handleCORSFiltered: aRequestContext
+
+	self addCORSHeadersTo: aRequestContext response.
+	super handleFiltered: aRequestContext.

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/handleCORSPreflight..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/handleCORSPreflight..st
@@ -1,0 +1,7 @@
+handling
+handleCORSPreflight: aRequestContext
+
+	| response |
+	response := aRequestContext response.
+	self addCORSHeadersTo: response.
+	aRequestContext respond

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/handleFiltered..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/handleFiltered..st
@@ -1,0 +1,11 @@
+handling
+handleFiltered: aRequestContext
+
+	"Pass on the aRequestContext to the next filter or handler. Subclasses might override this method to customize the request and response handling."
+
+	(self isPreflight: aRequestContext request)
+		ifTrue: [ self handleCORSPreflight: aRequestContext ]
+		ifFalse: [ 
+			(self isCORS: aRequestContext request) 
+				ifTrue: [ self handleCORSFiltered: aRequestContext ]
+				ifFalse: [ super handleFiltered: aRequestContext ]]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
@@ -1,0 +1,9 @@
+private
+initialize 
+	
+	super initialize.
+	allowedOrigins := OrderedCollection new.
+	allowedHeaders := OrderedCollection new.
+	allowedMethods := OrderedCollection new.
+	exposedHeaders := OrderedCollection new.
+	allowsCredentials := false

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/isCORS..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/isCORS..st
@@ -1,0 +1,4 @@
+testing
+isCORS: aRequest
+
+	^ (aRequest headerAt: 'origin') notNil

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/isPreflight..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/isPreflight..st
@@ -1,0 +1,4 @@
+testing
+isPreflight: aRequest
+
+	^ aRequest method = 'OPTIONS' and: [ self isCORS: aRequest ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllMethods.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllMethods.st
@@ -1,0 +1,4 @@
+methods
+removeAllMethods
+
+	self allowedMethods removeAll

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllowedOrigin..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllowedOrigin..st
@@ -1,0 +1,6 @@
+origins
+removeAllowedOrigin: originUrlString
+
+	self allowedOrigins remove: originUrlString asString ifAbsent: [ ]
+
+	

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/useExplicitMethods.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/useExplicitMethods.st
@@ -1,0 +1,4 @@
+methods
+useExplicitMethods
+
+	self allowedMethods addAll: self explicitMethods 

--- a/repository/Seaside-Core.package/WACORSFilter.class/properties.json
+++ b/repository/Seaside-Core.package/WACORSFilter.class/properties.json
@@ -1,0 +1,17 @@
+{
+	"commentStamp" : "EstebanMaringolo 8/11/2021 10:50",
+	"super" : "WARequestFilter",
+	"category" : "Seaside-Core-Filter",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"allowedOrigins",
+		"allowedMethods",
+		"allowedHeaders",
+		"exposedHeaders",
+		"allowsCredentials"
+	],
+	"name" : "WACORSFilter",
+	"type" : "normal"
+}

--- a/repository/Seaside-Core.package/WAUrl.class/instance/withoutResource.st
+++ b/repository/Seaside-Core.package/WAUrl.class/instance/withoutResource.st
@@ -1,0 +1,8 @@
+copying
+withoutResource
+
+	^ self copy
+		  path: OrderedCollection new;
+		  queryFields: nil;
+		  fragment: nil;
+		  yourself

--- a/repository/Seaside-Tests-Core.package/WAUrlTest.class/instance/testWithoutResource.st
+++ b/repository/Seaside-Tests-Core.package/WAUrlTest.class/instance/testWithoutResource.st
@@ -1,0 +1,13 @@
+tests-copy
+testWithoutResource
+	| copy |
+	url addField: 'foo' value: 'bar'.
+	url scheme: 'http'.
+	url host: 'localhost'.
+	url port: 9000.
+	
+	copy := url withoutResource.
+	url addToPath: 'zork'.
+	url addField: 'zork'.
+	self assert: url printString equals: 'http://localhost:9000/zork?foo=bar&zork'.
+	self assert: copy printString equals: 'http://localhost:9000/'

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/class/register.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/class/register.st
@@ -1,0 +1,5 @@
+initialization
+register
+	<script>
+
+	WAAdmin register: self asApplicationAt: 'corsTest'

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/baseUrl.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/baseUrl.st
@@ -1,0 +1,12 @@
+accessing-urls
+baseUrl
+
+	| parts url |
+	parts := self requestContext request host findTokens: ':'.
+	url := self requestContext request url withoutSeasideQueryFields 
+		       path: OrderedCollection new.
+
+	url host: parts first.
+	parts size > 1 ifTrue: [ url port: parts last asInteger ].
+
+	^ url

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/buildDataUrlFor.crossOrigin..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/buildDataUrlFor.crossOrigin..st
@@ -1,0 +1,13 @@
+accessing-urls
+buildDataUrlFor: host crossOrigin: crossOrigin
+
+	| port |
+	port := crossOrigin
+		        ifTrue: [ WACORSResourceExample corsAdaptorPort ]
+		        ifFalse: [WACORSResourceExample originAdaptorPort ].
+	^self baseUrl
+		 port: port;
+		 addToPath: 'tests';
+		 addToPath: 'corsData';
+		 addToPath: 'entries';
+		 yourself

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/corsFilter.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/corsFilter.st
@@ -1,0 +1,8 @@
+private
+corsFilter
+
+	^ [ 
+	  (WADispatcher default handlerAtAll: #( 'tests' 'corsData' ))
+		  filters detect: [ :each | each isKindOf: WACORSFilter ] ]
+		  on: Error
+		  do: [ :ex | ex return: nil ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/crossOriginDataUrl.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/crossOriginDataUrl.st
@@ -1,0 +1,8 @@
+accessing-urls
+crossOriginDataUrl
+
+	| parts host crossOrigin |
+	parts := self requestContext request host findTokens: ':'.
+	host := parts first.
+	crossOrigin := parts last asInteger == WACORSResourceExample originAdaptorPort.
+	^ self buildDataUrlFor: host crossOrigin: crossOrigin

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/errorHandlerFunction.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/errorHandlerFunction.st
@@ -1,0 +1,8 @@
+javascript
+errorHandlerFunction
+
+	^(JSStream on: 'console.error(arguments[0])') , (JSStream on:
+		   'document.getElementById("result").style.backgroundColor = "red"')
+	  , (JSStream on:
+			   'document.getElementById("result").innerHTML = "<p>Error</p>"') 
+		  asFunction: #( 'result' )

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/initialize.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/initialize.st
@@ -1,0 +1,4 @@
+private
+initialize 
+
+	super initialize.

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/originTextToUrlTable.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/originTextToUrlTable.st
@@ -1,0 +1,6 @@
+accessing
+originTextToUrlTable
+
+	^ OrderedDictionary
+		  with: 'Same Origin' -> self sameOriginDataUrl
+		  with: 'Cross Origin' -> self crossOriginDataUrl

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderAdaptorSetupOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderAdaptorSetupOn..st
@@ -1,0 +1,13 @@
+rendering
+renderAdaptorSetupOn: html
+
+	html paragraph:
+		'This test needs to setup a separate Seaside server adaptor, to handle requests at a different host:port, in order to make requests cross-origin.'.
+
+	html form: [ 
+		html button
+			callback: [ 
+				WACORSResourceExample
+					register;
+					registerCorsAdaptor ];
+			with: 'Register CORS Server adaptor' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterMethodsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterMethodsOn..st
@@ -1,0 +1,21 @@
+rendering-configuration
+renderCORSFilterMethodsOn: html
+
+	html heading
+		level2;
+		with: 'Currently allowed Methods.'.
+	self corsFilter allowedMethods
+		ifEmpty: [ html text: 'None' ]
+		ifNotEmpty: [ :allowed | html unorderedList list: allowed ].
+
+	html form: [ 
+		html button
+			callback: [ 
+				self corsFilter
+					addAllowedMethod: 'DELETE' ];
+			with: 'Allow DELETE'.
+		html space.
+
+		html button
+			callback: [ self corsFilter removeAllMethods ];
+			with: 'Remove all methods' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterOriginsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterOriginsOn..st
@@ -1,0 +1,28 @@
+rendering-configuration
+renderCORSFilterOriginsOn: html
+
+	html heading
+		level2;
+		with: 'Currently allowed Origins:'.
+	self corsFilter allowedOrigins
+		ifEmpty: [ html text: 'None' ]
+		ifNotEmpty: [ :origins | html unorderedList list: origins ].
+
+
+	html form: [ 
+		html button
+			callback: [ self corsFilter allowAnyOrigin ];
+			with: 'Allow any origin'.
+
+		html space.
+
+		html button
+			callback: [ 
+				self corsFilter
+					addAllowedOrigin: (self baseUrl asString allButLast) ];
+			with: 'Allow other origin'.
+		html space.
+
+		html button
+			callback: [ self corsFilter denyAllOrigins ];
+			with: 'Deny all origins' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderContentOn..st
@@ -1,0 +1,15 @@
+rendering
+renderContentOn: html
+
+	html heading: 'CORS Test Page'.
+
+	(WACORSResourceExample corsAdaptor isNil or: [ 
+		 WACORSResourceExample corsAdaptor isRunning not ])
+		ifTrue: [ 
+			self renderAdaptorSetupOn: html	
+			
+		]
+		ifFalse: [ 
+			self corsFilter
+				ifNil: [ self renderResourceRegistrationOn: html ]
+				ifNotNil: [ self renderTestingOn: html ] ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderMethodPreflightTestOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderMethodPreflightTestOn..st
@@ -1,0 +1,19 @@
+rendering-tests
+renderMethodPreflightTestOn: html
+
+	html heading
+		level2;
+		with: 'Make some DELETE requests'.
+	html paragraph:
+		'These test will trigger an OPTIONS preflight request when crossing origins.'.
+
+	self originTextToUrlTable keysAndValuesDo: [ :text :url | 
+		html button
+			onClick: ((JSStream on:
+						  ('fetch(<1p>, {method: "DELETE"})' expandMacrosWith:
+								   url asString))
+					 call: 'then'
+					 with: self successHandlerFunction
+					 with: self errorHandlerFunction);
+			with: text.
+		html space ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderRequestResultIndicatorOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderRequestResultIndicatorOn..st
@@ -1,0 +1,6 @@
+rendering
+renderRequestResultIndicatorOn: html
+
+	html div
+		id: 'result';
+		with: [  ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderResourceRegistrationOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderResourceRegistrationOn..st
@@ -1,0 +1,10 @@
+rendering
+renderResourceRegistrationOn: html
+
+	html paragraph:
+		('This test needs REST request handler located at <1p>.' 
+			 expandMacrosWith: WACORSResourceExample resourceUrl).
+	html form: [ 
+		html button
+			callback: [ WACORSResourceExample register ];
+			with: 'Register CORS Resource' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderSimpleRequestTestOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderSimpleRequestTestOn..st
@@ -1,0 +1,15 @@
+rendering-tests
+renderSimpleRequestTestOn: html
+
+	html heading
+		level2;
+		with: 'Make GET requests'.
+	self originTextToUrlTable keysAndValuesDo: [ :text :url | 
+		html button
+			onClick:
+				((JSStream on: ('fetch(<1p>)' expandMacrosWith: url asString))
+					 call: 'then'
+					 with: self successHandlerFunction
+					 with: self errorHandlerFunction);
+			with: text.
+		html space ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestingOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestingOn..st
@@ -1,0 +1,17 @@
+rendering
+renderTestingOn: html
+
+	html paragraph:
+		('This test will make asynchronous requests to a request handler at <1p>.' 
+			 expandMacrosWith: self corsFilter handler url).
+	html paragraph:
+		'We recommend opening the developer console and see the requests in the "Network tab".'.
+	html paragraph: [ 
+		html html:
+			'For more information about CORS <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">read this documentation at MDN</a>.' ].
+	html horizontalRule.
+	self renderCORSFilterOriginsOn: html.
+	self renderCORSFilterMethodsOn: html.
+	html horizontalRule.
+	self renderRequestResultIndicatorOn: html.
+	self renderTestsOn: html

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestsOn..st
@@ -1,0 +1,5 @@
+rendering
+renderTestsOn: html
+
+	self renderSimpleRequestTestOn: html.
+	self renderMethodPreflightTestOn: html

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/sameOriginDataUrl.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/sameOriginDataUrl.st
@@ -1,0 +1,8 @@
+accessing-urls
+sameOriginDataUrl
+
+	| parts host crossOrigin |
+	parts := self requestContext request host findTokens: ':'.
+	host := parts first.
+	crossOrigin := parts last asInteger == WACORSResourceExample originAdaptorPort.
+	^ self buildDataUrlFor: host crossOrigin: crossOrigin not

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/style.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/style.st
@@ -1,0 +1,10 @@
+accessing-urls
+style 
+
+	^'#result { 
+		width: 200px;
+		height: 40px;
+		color: white;
+		padding: 10px;
+	 }
+	'

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/successHandlerFunction.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/successHandlerFunction.st
@@ -1,0 +1,8 @@
+javascript
+successHandlerFunction
+
+	^(JSStream on: 'console.log(arguments[0])') , (JSStream on:
+		   'document.getElementById("result").style.backgroundColor = "darkgreen"')
+	  , (JSStream on:
+			   'document.getElementById("result").innerHTML = "<p>Success</p>"') 
+		  asFunction: #( 'result' )

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/properties.json
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "WAFunctionalTest",
+	"category" : "Seaside-Tests-Functional",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WACORSFilterFunctionalTest",
+	"type" : "normal"
+}

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/concreteAdaptorClass.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/concreteAdaptorClass.st
@@ -1,0 +1,4 @@
+accessing
+concreteAdaptorClass
+
+	^WAServerAdaptor withAllSubclasses detect: [ :one | one isAbstract not ]

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/corsAdaptor.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/corsAdaptor.st
@@ -1,0 +1,4 @@
+setup
+corsAdaptor
+
+	^corsAdaptor 

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/corsAdaptorPort.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/corsAdaptorPort.st
@@ -1,0 +1,4 @@
+accessing
+corsAdaptorPort
+
+	^ 9000

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/initialize.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/initialize.st
@@ -1,0 +1,5 @@
+initialization
+initialize
+
+	<script>
+	self register

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/originAdaptorPort.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/originAdaptorPort.st
@@ -1,0 +1,4 @@
+accessing
+originAdaptorPort
+
+	^ 8080

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/register.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/register.st
@@ -1,0 +1,5 @@
+setup
+register
+
+	<script>
+	WAAdmin register: self at: self resourceUrl

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/registerCorsAdaptor.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/registerCorsAdaptor.st
@@ -1,0 +1,5 @@
+setup
+registerCorsAdaptor
+
+	corsAdaptor := (self concreteAdaptorClass port: self corsAdaptorPort)
+		               start

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/resourceUrl.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/resourceUrl.st
@@ -1,0 +1,4 @@
+setup
+resourceUrl
+
+	^ 'tests/corsData'

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/startAdaptors.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/startAdaptors.st
@@ -1,0 +1,23 @@
+setup
+startAdaptors
+
+	<script>
+	WAServerManager default adaptors
+		ifEmpty: [ 
+			originAdaptor := (self concreteAdaptorClass port:
+				                  self originAdaptorPort) start.
+			self registerCorsAdaptor ]
+		ifNotEmpty: [ :adaptors | 
+			originAdaptor := adaptors
+				                 detect: [ :one | 
+				                 one port = self originAdaptorPort ]
+				                 ifFound: [ :adaptor | adaptor start ]
+				                 ifNone: [ 
+				                 (self concreteAdaptorClass port:
+					                  self originAdaptorPort) start ].
+			corsAdaptor := adaptors
+				               detect: [ :one | one port = self corsAdaptorPort ]
+				               ifFound: [ :adaptor | adaptor start ]
+				               ifNone: [ 
+				               (self concreteAdaptorClass port:
+					                self corsAdaptorPort) start ] ]

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/unregister.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/class/unregister.st
@@ -1,0 +1,5 @@
+setup
+unregister
+
+	<script>
+	WAAdmin unregister: self resourceUrl

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/deleteEntry.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/deleteEntry.st
@@ -1,0 +1,7 @@
+routes
+deleteEntry
+
+	<method: 'DELETE'>
+	<path: 'entries'>
+	<produces: 'application/json'>
+	^ self sampleData removeFirst asJson

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/getEntries.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/getEntries.st
@@ -1,0 +1,8 @@
+routes
+getEntries
+
+	<method: 'GET'>
+	<path: 'entries'>
+	<produces: 'application/json'>
+
+	^self sampleData asJson

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/initialize.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/initialize.st
@@ -1,0 +1,5 @@
+private 
+initialize 
+
+	super initialize.
+	self addFilterFirst: WACORSFilter new.

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/initializeSampleData.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/initializeSampleData.st
@@ -1,0 +1,9 @@
+private 
+initializeSampleData
+
+	^ sampleData := ((1 to: 10) collect: [ :index | 
+		                 Dictionary new
+			                 at: 'id' put: index;
+			                 at: 'title'
+			                 put: ('Item <1p>' expandMacrosWith: 2);
+			                 yourself ]) asOrderedCollection

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/sampleData.st
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/instance/sampleData.st
@@ -1,0 +1,5 @@
+private 
+sampleData
+
+	sampleData ifNil: [ self initializeSampleData ].
+	^ sampleData

--- a/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/properties.json
+++ b/repository/Seaside-Tests-Functional.package/WACORSResourceExample.class/properties.json
@@ -1,0 +1,16 @@
+{
+	"commentStamp" : "",
+	"super" : "WARestfulHandler",
+	"category" : "Seaside-Tests-Functional",
+	"classinstvars" : [
+		"originAdaptor",
+		"corsAdaptor"
+	],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"sampleData"
+	],
+	"name" : "WACORSResourceExample",
+	"type" : "normal"
+}


### PR DESCRIPTION
I implemented a basic CORS filter with a functional test (including setting up a separate server adaptor to handle cross-origin requests).

It would be great to merge this into the upcoming release, so it can be ported to VAST (and other dialects).