### PR TITLE
CI: fix load of latest Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
           smalltalk-image: ${{ matrix.smalltalk }}
       - name: Install Chrome
         run: |
-          sudo apt install google-chrome-beta
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get -y install google-chrome-stable
       - name: Install selenium
         run: npm install selenium-standalone && npx selenium-standalone install && npx selenium-standalone start &
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           smalltalk-image: ${{ matrix.smalltalk }}
       - name: Install Chrome
         run: |
-          sudo apt install google-chrome-stable
+          sudo apt install google-chrome-beta
       - name: Install selenium
         run: npm install selenium-standalone && npx selenium-standalone install && npx selenium-standalone start &
       - name: Run tests


### PR DESCRIPTION
The CI step to load Chrome needs to set the Google repo as the source so we always load the actual latest stable.

This fixes the CI.