### PR TITLE
Fix WAMutexTest>>testSelfTerminate

### DIFF
--- a/repository/Seaside-Tests-Core.package/WAMutexTest.class/instance/testSelfTerminate.st
+++ b/repository/Seaside-Tests-Core.package/WAMutexTest.class/instance/testSelfTerminate.st
@@ -1,15 +1,15 @@
 tests
 testSelfTerminate
-	| value semaphore |
+	| value |
 	value := nil.
-	semaphore := GRPlatform current semaphoreClass new.
 	process := 
 	[ value := mutex critical: 
-		[ semaphore signal.
-		mutex terminateOwner.
-		1 ] ] newProcess.
-	process resume.
-	semaphore wait.
+		[ mutex terminateOwner.
+        1 ] ] newProcess.
+	process 
+		priority: Processor activeProcess priority + 1;
+		resume.
+	Processor yield.  "<--- required for GemStone prior to 3.7"
 	self assert: mutex owner isNil.
 	self assert: value isNil.
 	self assert: (GRPlatform current isProcessTerminated: process)


### PR DESCRIPTION
Use process priority rather than semaphore to ensure the spawned process is terminated in the test case.
See #1291 for more info.
Thanks @martinmcclure for the test fix!