### PR TITLE
Baseline parasol cycle reversal

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -27,11 +27,6 @@ SmalltalkCISpec {
       #platforms : [ #gemstone ]
     }
   ],
-  #postLoading : [
-    SCICustomScript {
-      #path : 'scripts/loadParasolAndTests.st'
-    }
-  ],
   #testing : {
       #defaultTimeout : 30,
       #exclude : {

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
@@ -26,6 +26,12 @@ baselinecommon: spec
 	].
 
 	spec for: #'common' do: [
+		 spec
+			baseline: 'Parasol'
+        	with: [ 
+				spec
+					repository: 'github://SeasideSt/Parasol:master/repository';
+					load: 'default' ].
 		spec
 			package: 'Seaside-Canvas' with: [
 				spec requires: #('Seaside-Core' ). ];
@@ -86,14 +92,13 @@ baselinecommon: spec
 			package: 'Seaside-Tests-UTF8' with: [
 				spec requires: #('Seaside-Tests-Core' ) ];
 			package: 'Seaside-Tests-Parasol' with: [
-				spec requires: #('Seaside-Tests-Functional' 'Seaside-Tools-Core') ].
+				spec requires: #('Parasol' 'Seaside-Tests-Functional' 'Seaside-Tools-Core') ].
 		spec 
 			group: 'default' with: #('Core' 'JSON' 'Email' 'Javascript' 'JQuery' 'JQueryUI' 'Seaside-Examples' 'Seaside-Welcome');
 			group: 'OneClick' with: #('Tests' 'Development' 'Zinc');
 			group: 'CI' with: #('Tests' 'Development Tests');
 			group: 'Core' with: #('Seaside-Core' 'Seaside-Continuation' 'Seaside-Canvas' 'Seaside-Session' 'Seaside-Component' 'Seaside-RenderLoop' 'Seaside-Tools-Core' 'Seaside-Flow' 'Seaside-Environment' 'Seaside-Widgets' );
-			group: 'Tests' with: #('Core' 'Seaside-Tests-Core' 'Seaside-Tests-Canvas' 'Seaside-Tests-Session' 'Seaside-Tests-Component' 'Seaside-Tests-RenderLoop' 'Seaside-Tests-Environment' 'Seaside-Tests-Flow' 'Seaside-Tests-UTF8' 'Seaside-Tests-InternetExplorer' 'Seaside-Tests-Email' 'Seaside-Tests-Examples' 'RSS Tests' 'Welcome Tests' 'REST Tests' 'Swagger Tests');
-			group: 'Parasol-Tests' with: #('Seaside-Tests-Parasol');
+			group: 'Tests' with: #('Core' 'Seaside-Tests-Core' 'Seaside-Tests-Canvas' 'Seaside-Tests-Session' 'Seaside-Tests-Component' 'Seaside-Tests-RenderLoop' 'Seaside-Tests-Environment' 'Seaside-Tests-Flow' 'Seaside-Tests-UTF8' 'Seaside-Tests-InternetExplorer' 'Seaside-Tests-Email' 'Seaside-Tests-Examples' 'RSS Tests' 'Welcome Tests' 'REST Tests' 'Swagger Tests' 'Seaside-Tests-Parasol');
 			group: 'Development' with: #('Core' 'Seaside-Development' );
 			group: 'Development Tests' with: #('Development' 'Core' 'Seaside-Tests-Development' );
 			group: 'Email' with: #('Seaside-Email');

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
@@ -31,7 +31,7 @@ baselinecommon: spec
         	with: [ 
 				spec
 					repository: 'github://SeasideSt/Parasol:master/repository';
-					load: 'default' ].
+					loads: 'default' ].
 		spec
 			package: 'Seaside-Canvas' with: [
 				spec requires: #('Seaside-Core' ). ];


### PR DESCRIPTION
We broke the dependency of Parasol on Seaside in https://github.com/SeasideSt/Parasol/pull/52 to make loading of Parasol in Metacello projects easier to deal with.
A year back (e.g. https://github.com/SeasideSt/Seaside/commit/a30e9be0f959ff9fc813eebb831aca9241759174), we broke the dependency from Seaside to Parasol, but this proves to be complicating builds that load Seaside and want to run the Seaside Functional tests with Parasol.

By removing the dependency of Parasol on Seaside _and_ pulling in Parasol automatically when loading the Seaside tests, we hope to reverse the problem of the dependency cycle in a more convenient way for those projects.