### PR TITLE
More tests and fixes

### DIFF
--- a/repository/Seaside-Tests-Flow.package/WAFlowErrorFunctionalTest.class/instance/renderErrorWithCallOn..st
+++ b/repository/Seaside-Tests-Flow.package/WAFlowErrorFunctionalTest.class/instance/renderErrorWithCallOn..st
@@ -4,4 +4,4 @@ renderErrorWithCallOn: html
 	html paragraph: 'A message should be displayed. Once you click the button, behaviour should be identical to the Error case above without a call. If not, we may have a problem with continuations holding onto the request context.'.
 	html anchor
 		callback: [ self inform: 'Once you close this, an error will be raised.'. self raiseError ];
-		with: 'Raise error'
+		with: 'Raise error in called component'

--- a/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderHandlerConfigurationOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderHandlerConfigurationOn..st
@@ -2,7 +2,7 @@ rendering
 renderHandlerConfigurationOn: html
 	| attribute filter |
 	filter := self exceptionFilter.
-	filter isNil ifTrue: [
+	filter ifNil: [
 		html paragraph: 'Exception handler configuration attribute not found!'.
 		^ self ].
 	attribute := filter configuration attributeAt: #exceptionHandler.
@@ -10,12 +10,15 @@ renderHandlerConfigurationOn: html
 	html form: [
 		html div: [
 			html select
+				id: #handlerselect;
 				beOptional;
 				optionalLabel: '(inherited default)';
 				list: attribute options asArray;
 				selected: (filter configuration at: attribute key);
 				callback: [ :value | 
-					value isNil
-						ifTrue: [ filter configuration removeExpressionAt: attribute key ifAbsent: [ ] ]
-						ifFalse: [ filter configuration takeValue: value forAttribute: attribute ] ].
-			html submitButton with: 'Set Handler' ] ]
+					value
+						ifNil: [ filter configuration removeExpressionAt: attribute key ifAbsent: [ ] ]
+						ifNotNil: [ filter configuration takeValue: value forAttribute: attribute ] ].
+			html submitButton 
+				id: #sethandler; 
+				with: 'Set Handler' ] ]

--- a/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderPostErrorOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderPostErrorOn..st
@@ -7,4 +7,4 @@ renderPostErrorOn: html
 		with: [
 			html button
 				callback: [ self raiseError ];
-			with: 'Raise error' ]
+			with: 'Raise error in POST' ]

--- a/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderRenderErrorOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAExceptionFunctionalTest.class/instance/renderRenderErrorOn..st
@@ -11,4 +11,4 @@ renderRenderErrorOn: html
 	html paragraph: 'This will trigger an error during the next render phase.'.
 	html anchor
 		callback: [ renderError := true ];
-		with: 'Raise error'
+		with: 'Raise error during rendering'

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/expectedFailures.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/expectedFailures.st
@@ -1,7 +1,7 @@
 running
 expectedFailures
 	| todo |
-	todo := #(testExceptionFunctionalTest testExpiryFunctionalTest testFilterFunctionalTest testFlowErrorFunctionalTest testUploadFunctionalTest).
+	todo := #(testExpiryFunctionalTest testFilterFunctionalTest testUploadFunctionalTest).
 	^ (GRPlatform current class == (Smalltalk at: #GRGemStonePlatform ifAbsent:[ nil ]))
 		ifTrue: [ #(testContextFunctionalTest), todo "requires https://github.com/GsDevKit/Grease/pull/17 to be merged" ]
 		ifFalse:[  todo ]

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/scrollWindowBy..st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/scrollWindowBy..st
@@ -1,0 +1,5 @@
+helpers
+scrollWindowBy: distancePoint
+
+	driver executeScript: 'window.scrollBy(arguments[0], arguments[1])'
+		with: { distancePoint x. distancePoint y }.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateSelectorFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateSelectorFunctionalTest.st
@@ -4,7 +4,7 @@ testDateSelectorFunctionalTest
 	| fromDate toDate fromDateSelects toDateSelects fromTime toTime fromTimeSelects toTimeSelects deltaTime fromDateAndTime deltaDuration toDateAndTime fromDateAndTimeSelects toDateAndTimeSelects |
 	self selectTest: 'WADateSelectorFunctionalTest'.
 
-  fromDate := Date fromString: '11/5/2020'.
+  fromDate := Date fromString: '11/5/2022'.
   toDate := fromDate addDays: 300.
 	
 	fromDateSelects := (((driver findElementByID: #dateForm) findElementByClassName: 'from') findElementsByTagName: 'select').

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
@@ -22,7 +22,7 @@ testExceptionFunctionalTest
 	driver goBack.
 	
 	(driver findElementByLinkText: 'Raise zero divide') click.
-	self assert: (driver findElementByTagName: 'h1') getText equals: 'ZeroDivide'.
+	self assert: ((driver findElementByTagName: 'h1') getText includesSubstring: 'ZeroDivide').
 	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
 	driver goBack.
 	

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
@@ -2,5 +2,37 @@ testing
 testExceptionFunctionalTest
 
 	self selectTest: 'WAExceptionFunctionalTest'.
-	"need to figure out how to make this work cross-platform... not impossible, just time and work"
-	self fail.
+
+	(BPSelect on: (driver findElementByID: 'handlerselect')) selectByVisibleText: 'WAHtmlErrorHandler'.
+	(driver findElementByID: #sethandler) click.
+
+	(driver findElementByLinkText: 'Raise error') click.
+	self assert: (driver findElementByTagName: 'h1') getText equals: 'WAError: Test Error'.
+	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
+	driver goBack.
+	
+	((driver findElementsByCSSSelector: 'button[type=submit]') detect: [ :i | i getText = 'Raise error in POST' ]) click.
+	self assert: (driver findElementByTagName: 'h1') getText equals: 'WAError: Test Error'.
+	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
+	driver goBack.
+	
+	(driver findElementByLinkText: 'Raise error during rendering') click.
+	self assert: ((driver findElementsByTagName: 'h1') anySatisfy: [ :e | e getText = 'WAError: Error during rendering.' ]).
+	self assert: ((driver findElementsByTagName: 'p') anySatisfy: [ :e | e getText = 'Your request could not be completed. An exception occurred.' ]).
+	driver goBack.
+	
+	(driver findElementByLinkText: 'Raise zero divide') click.
+	self assert: (driver findElementByTagName: 'h1') getText equals: 'ZeroDivide'.
+	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
+	driver goBack.
+	
+	self scrollWindowBy: 10@800 "need to scroll into view, especially when running headful".
+	(driver findElementByLinkText: 'Raise warning') click.
+	self assert: (driver findElementByTagName: 'h1') getText equals: 'Warning: Test Warning'.
+	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
+	driver goBack.
+
+	self scrollWindowBy: 10@800 "need to scroll into view, especially when running headful".
+	(driver findElementByLinkText: 'Raise deprecated') click.
+	self assert: (driver findElementByTagName: 'h3') getText equals: 'To be displayed'.
+	((driver findElementsByCSSSelector: 'input[type=submit]') detect: [ :i | (i getAttribute: 'value') = 'Ok' ]) click.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowErrorFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowErrorFunctionalTest.st
@@ -3,4 +3,16 @@ testFlowErrorFunctionalTest
 
 	self selectTest: 'WAFlowErrorFunctionalTest'.
 
-	self fail.
+	(BPSelect on: (driver findElementByID: 'handlerselect')) selectByVisibleText: 'WAHtmlErrorHandler'.
+	(driver findElementByID: #sethandler) click.
+	(driver findElementByLinkText: 'Raise error') click.
+	self assert: (driver findElementByTagName: 'h1') getText = 'WAError: Test Error'.
+	self assert: (driver findElementByTagName: 'p') getText = 'Your request could not be completed. An exception occurred.'.
+	driver goBack.
+	
+	(driver findElementByLinkText: 'Raise error in called component') click.
+	self assert: (driver findElementByTagName: 'h3') getText = 'Once you close this, an error will be raised.'.
+	((driver findElementsByCSSSelector: 'input[type=submit]') detect: [ :i | (i getAttribute: 'value') = 'Ok' ]) click.
+	
+	self assert: (driver findElementByTagName: 'h1') getText = 'WAError: Test Error'.
+	self assert: (driver findElementByTagName: 'p') getText = 'Your request could not be completed. An exception occurred.'.


### PR DESCRIPTION
Some fixes and additions to the parasol tests executing the functional tests:
- The functional date test was erroring since January 1st 2022 because the selector does not display the year 2020 anymore
- Added tests for exception handler testing