### PR TITLE
Pharo9+ UTF8 encoding support using ZnUTF8Encoder

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
@@ -7,7 +7,7 @@ baselinecommon: spec
         	with: [ 
 				spec
 					loads: #('Grease-Core');
-					repository: 'github://SeasideSt/Grease:master/repository' ].
+					repository: 'github://SeasideSt/Grease:v1.8.x/repository' ].
 		spec
 			project: 'Grease Core Tests' copyFrom: 'Grease' with: [ 
 				spec loads: #('Core Tests') ] 

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
@@ -7,7 +7,7 @@ baselinecommon: spec
         	with: [ 
 				spec
 					loads: #('Grease-Core');
-					repository: 'github://SeasideSt/Grease:v1.7.x/repository' ].
+					repository: 'github://SeasideSt/Grease:master/repository' ].
 		spec
 			project: 'Grease Core Tests' copyFrom: 'Grease' with: [ 
 				spec loads: #('Core Tests') ] 

--- a/repository/Seaside-Core.package/WABufferedResponse.class/instance/writeContentAsStringOn..st
+++ b/repository/Seaside-Core.package/WABufferedResponse.class/instance/writeContentAsStringOn..st
@@ -1,0 +1,3 @@
+writing
+writeContentAsStringOn: aStream 
+	aStream nextPutAll: self contents asString

--- a/repository/Seaside-Core.package/WAComboResponse.class/instance/writeContentAsStringOn..st
+++ b/repository/Seaside-Core.package/WAComboResponse.class/instance/writeContentAsStringOn..st
@@ -1,0 +1,4 @@
+writing
+writeContentAsStringOn: aStream 
+	committed ifFalse: [ 
+		aStream nextPutAll: self contents asString ]

--- a/repository/Seaside-Core.package/WAResponse.class/instance/writeContentAsStringOn..st
+++ b/repository/Seaside-Core.package/WAResponse.class/instance/writeContentAsStringOn..st
@@ -1,0 +1,3 @@
+writing
+writeContentAsStringOn: aStream
+	self subclassResponsibility

--- a/repository/Seaside-Core.package/WAResponse.class/instance/writeOn..st
+++ b/repository/Seaside-Core.package/WAResponse.class/instance/writeOn..st
@@ -1,7 +1,8 @@
 writing
 writeOn: aStream
+	"Note: only works if the stream's collection class is a String (used for test/development purposes only"
 	self writeStatusOn: aStream.
 	self writeHeadersOn: aStream.
 	self writeCookiesOn: aStream.
 	aStream crlf.
-	self writeContentOn: aStream
+	self writeContentAsStringOn: aStream

--- a/repository/Seaside-Core.package/WAServerAdaptor.class/instance/responseFor..st
+++ b/repository/Seaside-Core.package/WAServerAdaptor.class/instance/responseFor..st
@@ -2,4 +2,4 @@ converting
 responseFor: aNativeRequest
 	"Answer a response object for aNativeRequest."
 
-	^ WABufferedResponse on: (self codec encoderFor: (GRPlatform current writeCharacterStreamOn: String new))
+	^ WABufferedResponse on: (self codec encoderFor: (GRPlatform current writeCharacterStreamOn: (self codec encodedStringClass) new))

--- a/repository/Seaside-Core.package/WAStreamedResponse.class/instance/writeContentAsStringOn..st
+++ b/repository/Seaside-Core.package/WAStreamedResponse.class/instance/writeContentAsStringOn..st
@@ -1,0 +1,3 @@
+writing
+writeContentAsStringOn: aStream
+	committed := true

--- a/repository/Seaside-Core.package/WAUrlEncoder.class/instance/nextPut..st
+++ b/repository/Seaside-Core.package/WAUrlEncoder.class/instance/nextPut..st
@@ -4,6 +4,6 @@ nextPut: aCharacter
 	value := aCharacter greaseInteger.
 	encoded := table at: value + 1.
 	"Issue 482: use #notNil because it is faster than #isString because it is not actually sent"
-	encoded notNil
+	encoded notNil 
 		ifTrue: [ stream nextPutAll: encoded ]
-		ifFalse: [ stream nextPut: aCharacter ]
+		ifFalse: [ stream nextPut: aCharacter asCharacter ]

--- a/repository/Seaside-Tests-Core.package/WAResponseTest.class/instance/assertLines..st
+++ b/repository/Seaside-Tests-Core.package/WAResponseTest.class/instance/assertLines..st
@@ -1,3 +1,3 @@
 private
 assertLines: anArray
-	self assert: self lines = anArray
+	self assert: self lines equals: anArray

--- a/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/asByteArray..st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/asByteArray..st
@@ -1,0 +1,5 @@
+private
+asByteArray: aCollectionOfIntegers
+	^ ByteArray streamContents: [ :stream |
+		aCollectionOfIntegers do: [ :each |
+			stream nextPut: each ] ]

--- a/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecMacRoman.st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecMacRoman.st
@@ -7,6 +7,8 @@ testGenericCodecMacRoman
 	self assert: codec url name = 'utf-8'.
 	self assert: ((codec url isKindOf: GRPharoUtf8Codec) or:[ codec url isKindOf: GRPharoDeprecatedUtf8Codec ]).
 	self assert: (codec encode: self latin1String) = self macromanString.
-	self assert: (codec url encode: self latin1String) = self utf8String.
+	codec url encodedStringClass == ByteArray
+		ifTrue:[ self assert: (codec url encode: self latin1String) = self utf8ByteArray ]
+		ifFalse:[ self assert: (codec url encode: self latin1String) = self utf8String ].
 	self assert: (codec decode: self macromanString) = self latin1String.
 	self assert: (codec url decode: self utf8String) = self latin1String

--- a/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecUtf16be.st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecUtf16be.st
@@ -8,7 +8,9 @@ testGenericCodecUtf16be
 	self assert: codec url name = 'utf-8'.
 	self assert: ((codec url isKindOf: GRPharoUtf8Codec) or:[ codec url isKindOf: GRPharoDeprecatedUtf8Codec ]).
 	self assert: (codec encode: self latin1String) = self utf16beString.
-	self assert: (codec url encode: self latin1String) = self utf8String.
+	codec url encodedStringClass == ByteArray
+		ifTrue:[ self assert: (codec url encode: self latin1String) = self utf8ByteArray ]
+		ifFalse:[ self assert: (codec url encode: self latin1String) = self utf8String ].
 	self assert: (codec decode: self utf16beString) = self latin1String.
 	self assert: (codec decode: bom , self utf16beString) = self latin1String.
 	self assert: (codec url decode: self utf8String) = self latin1String

--- a/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecUtf16le.st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/testGenericCodecUtf16le.st
@@ -8,6 +8,9 @@ testGenericCodecUtf16le
 	self assert: codec url name = 'utf-8'.
 	self assert: ((codec url isKindOf: GRPharoUtf8Codec) or:[ codec url isKindOf: GRPharoDeprecatedUtf8Codec ]).
 	self assert: (codec encode: self latin1String) = self utf16beString.
-	self assert: (codec url encode: self latin1String) = self utf8String.
+	codec url encodedStringClass == ByteArray
+		ifTrue:[ self assert: (codec url encode: self latin1String) = self utf8ByteArray ]
+		ifFalse:[ self assert: (codec url encode: self latin1String) = self utf8String ].
 	self assert: (codec decode: bom , self utf16leString) = self latin1String.
 	self assert: (codec url decode: self utf8String) = self latin1String
+	

--- a/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/utf8ByteArray.st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAGenericCodecTest.class/instance/utf8ByteArray.st
@@ -1,0 +1,3 @@
+private
+utf8ByteArray
+	^ self asByteArray: #(195 156 98 195 168 114 115 116 114 195 174 195 177 103 195 169)

--- a/repository/Seaside-Tests-Pharo-Core.package/WAPharoEncoderTest.class/instance/assert.next.startingAt.encoder.gives..st
+++ b/repository/Seaside-Tests-Pharo-Core.package/WAPharoEncoderTest.class/instance/assert.next.startingAt.encoder.gives..st
@@ -4,4 +4,4 @@ assert: aString next: anInteger startingAt: startIndex encoder: aClass gives: an
 	actual := String streamContents: [ :stream |
 		(aClass on: stream codec: self requestContext codec)
 			greaseNext: anInteger putAll: aString startingAt: startIndex ].
-	self assert: actual = anEncodedString
+	self assert: actual equals: anEncodedString

--- a/repository/Seaside-Tests-Session.package/WASessionTest.class/instance/testRegisterDocumentHandler.st
+++ b/repository/Seaside-Tests-Session.package/WASessionTest.class/instance/testRegisterDocumentHandler.st
@@ -31,8 +31,8 @@ testRegisterDocumentHandler
 	[  handler handle: context ]
 		on: WAResponseNotification
 		do: [ :notification | ].
-	self assert: response status = WAResponse statusOk.
-	self assert: response contents = documentHandler document contents.
+	self assert: response status equals: WAResponse statusOk.
+	self assert: response contents equals: documentHandler document contents.
 	
 	"dispatch to a not existing handler"
 	url := url copy.

--- a/repository/Seaside-Tests-UTF8.package/WABufferedResponseTest.extension/instance/testResetKeepsStreamKind.st
+++ b/repository/Seaside-Tests-UTF8.package/WABufferedResponseTest.extension/instance/testResetKeepsStreamKind.st
@@ -1,9 +1,10 @@
 *seaside-tests-utf8
 testResetKeepsStreamKind
-	| resetPossible |
+	| resetPossible codec |
+	codec := GRCodec forEncoding: 'utf-8'.
 	response := WABufferedResponse
-		on: ((GRCodec forEncoding: 'utf-8')
-			encoderFor: (GRPlatform current writeCharacterStreamOn: String new)).
+		on: (codec
+			encoderFor: (GRPlatform current writeCharacterStreamOn: codec encodedStringClass new)).
 	resetPossible := self response
 		status: WAResponse statusNotFound;
 		attachmentWithFileName: 'upload.csv';

--- a/repository/Zinc-Seaside.package/ZnZincStreamingServerAdaptor.class/instance/responseFor..st
+++ b/repository/Zinc-Seaside.package/ZnZincStreamingServerAdaptor.class/instance/responseFor..st
@@ -1,7 +1,7 @@
 converting
 responseFor: aZnRequest
 	| bufferedStream codecStream |
-	bufferedStream := GRPlatform current writeCharacterStreamOn: (String new: 4096).
+	bufferedStream := GRPlatform current writeCharacterStreamOn: (self codec encodedStringClass new: 4096).
 	codecStream := self codec encoderFor: bufferedStream. 
 	^ WAComboResponse
 		onBuffered: (GRCountingStream on: codecStream)


### PR DESCRIPTION
- Use the GRCodec>>encodedStringClass when initializing WAResponse subinstances
- Some utility methods for writing responses on a String-based stream for testing
- WAURLEncoder requires to encode UTF8 to a String always