### PR TITLE
Delegates JSObject>>#script:on: document creation to the requestContext.

### DIFF
--- a/repository/Javascript-Core.package/JSObject.class/instance/script.on..st
+++ b/repository/Javascript-Core.package/JSObject.class/instance/script.on..st
@@ -3,11 +3,7 @@ script: aBlock on: aStream
 	"Evaluate aBlock and pass in a script object that is subsequently written to aStream."
 
 	| script document |
-	document := (WAHtmlDocument
-		on: aStream
-		codec: self requestContext codec)
-		scriptGenerator: self requestContext handler scriptGeneratorClass new;
-		yourself.
+	document := (self requestContext newDocumentOn: aStream).
 	self renderContext document: document during: [ 
 		script := (JSScript context: self renderContext)
 			rendererClass: self rendererClass;

--- a/repository/Seaside-Core.package/WARequestContext.class/instance/newDocument.st
+++ b/repository/Seaside-Core.package/WARequestContext.class/instance/newDocument.st
@@ -3,15 +3,5 @@ newDocument
 	"Answer a new Document configured to write onto our Response's stream using the
 	current Codec. Try to use the Document class specified by the closest Handler
 	but fall back on WAHtmlDocument if there is none."
-	
-	^ self handler isNil
-		ifTrue: [
-			(WAHtmlDocument
-				on: self response stream codec: self codec)
-				scriptGenerator: WADefaultScriptGenerator new;
-				yourself  ]
-		ifFalse: [
-			(self handler documentClass
-				on: self response stream codec: self codec)
-				scriptGenerator: self handler scriptGeneratorClass new;
-				yourself ]
+
+	^ self newDocumentOn: self response stream

--- a/repository/Seaside-Core.package/WARequestContext.class/instance/newDocumentOn..st
+++ b/repository/Seaside-Core.package/WARequestContext.class/instance/newDocumentOn..st
@@ -1,0 +1,16 @@
+accessing-dynamic
+newDocumentOn: outputStream
+	"Answer a new Document configured to write onto outputStream using the
+	current Codec. Try to use the Document class specified by the closest Handler
+	but fall back on WAHtmlDocument if there is none."
+
+
+	^ self handler isNil
+		  ifTrue: [ 
+			  (WAHtmlDocument on: outputStream codec: self codec)
+				  scriptGenerator: WADefaultScriptGenerator new;
+				  yourself ]
+		  ifFalse: [ 
+			  (self handler documentClass on: outputStream codec: self codec)
+				  scriptGenerator: self handler scriptGeneratorClass new;
+				  yourself ]


### PR DESCRIPTION
When you render something by means of instantiating your own WABuilder, there was an unnecessary reference to the handler to obtain the scriptGenerator class.

This change delegates such decision to `WARequestContext>>#newDocument` which already considers the case of a nil handler.

I ran all the tests and it passes without issues, since it's mostly a refactoring.