### PR TITLE
Fix#1307 - Replace obsolete message send with functional equivalent

### DIFF
--- a/repository/Seaside-Pharo-Development.package/WAPharoWalkback.class/instance/tempNamesAndValuesIn.do..st
+++ b/repository/Seaside-Pharo-Development.package/WAPharoWalkback.class/instance/tempNamesAndValuesIn.do..st
@@ -4,6 +4,5 @@ tempNamesAndValuesIn: aContext do: aTwoArgumentBlock
 		and: [ SystemVersion current major >= 8 ])
 		or: [ (SystemVersion current asString includesSubstring: 'Squeak')
 				and: [ SystemVersion current majorVersionNumber >= 5 ] ])
-		ifTrue: [ aContext tempNames
-				doWithIndex:
-					[ :each :index | aTwoArgumentBlock value: each value: (aContext namedTempAt: index) ] ]
+		ifTrue: [aContext tempNames do:
+					[ :each | aTwoArgumentBlock value: each value: (aContext tempNamed: each) ]]


### PR DESCRIPTION
WAPharoWalkback resulted in "Internal Error" on Pharo 10 when  'renderContentOn:' is incorrect.

This is because the variable listing method referred to Context>>tempNamedAt: which was deprecated in 9.0 and has gone in 10.0.  Replaced with functionally equivalent iteration over temp vars.