### PR TITLE
Fix WAVersionUploader

### DIFF
--- a/repository/Seaside-Pharo-Tools-Web.package/WAVersionUploader.class/instance/newVersion..st
+++ b/repository/Seaside-Pharo-Tools-Web.package/WAVersionUploader.class/instance/newVersion..st
@@ -1,10 +1,10 @@
 actions
 newVersion: aWorkingCopy
 	| version stream |
-	version := [ aWorkingCopy newVersion ]
+	version := [ aWorkingCopy newVersionIn: aWorkingCopy repositoryGroup ]
 		on: MCVersionNameAndMessageRequest
 		do: [ :request | request resume: (Array with: request suggestedName with: '') ].
-	stream := RWBinaryOrTextStream on: String new.
+	stream := GRPlatform current readWriteByteStream.
 	version fileOutOn: stream.
 	self requestContext respond: [ :response |
 		response


### PR DESCRIPTION
Fixes the version uploader on Pharo 10.

- `RWBinaryOrTextStream` was undeclared
- `#newVersion` was not implemented