### PR TITLE
Handle UTF-16 surrogate pairs in WAJsonParser

### DIFF
--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/README.md
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/README.md
@@ -1,3 +1,10 @@
-I am a parser for JSON. It is a bit more forgiving than the standard and allows any kind of top level element except numbers, not just {} and []. See http://www.json.org/ for details.
+I am a parser for JSON. I follow RFC-8259 / ECMA-404 and allow any kind of value as a root object.
 
-I can be subclasses to create more sophisticated objects than just Arrays and Dictionaries. To do that, override the one or more methods in the creating protocol.
+I convert surrogate pairs to a single code point.
+
+I can be subclassed to create more sophisticated objects than just Arrays and Dictionaries. To do that, override the one or more methods in the "creating" protocol.
+
+See
+https://datatracker.ietf.org/doc/html/rfc8259
+https://www.ecma-international.org/publications-and-standards/standards/ecma-404/
+https://datatracker.ietf.org/doc/html/rfc4627

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/createCodePointFromSurrogatesHigh.low..st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/createCodePointFromSurrogatesHigh.low..st
@@ -1,0 +1,3 @@
+parsing-internal
+createCodePointFromSurrogatesHigh: aHighInteger low: aLowInteger
+	^ 16r10000 + ((aHighInteger - 16rD800 bitShift: 10) bitOr: (aLowInteger - 16rDC00))

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/isHighSurrogate..st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/isHighSurrogate..st
@@ -1,0 +1,3 @@
+private
+isHighSurrogate: anInteger
+	^ anInteger between: 16rD800 and: 16rDBFF

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/isLowSurrogate..st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/isLowSurrogate..st
@@ -1,0 +1,3 @@
+private
+isLowSurrogate: anInteger
+	^ anInteger between: 16rDC00 and: 16rDFFF

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
@@ -2,13 +2,16 @@ parsing-internal
 parseCharacterHex
 	| value |
 	value := self parseCharacterHexRaw.
-	(self isHighSurrogate: value) ifTrue: [
-		| lowSurrogate |
-		self expectChar: $\.
-		self expectChar: $u.
-		lowSurrogate := self parseCharacterHexRaw.
-		(self isLowSurrogate: lowSurrogate) ifFalse: [
-			^ self error: 'low surrogate expected' ].
-		value := 16r10000 + ((value - 16rD800 bitShift: 10) bitOr: (lowSurrogate - 16rDC00)) ].
-	(self isLowSurrogate: value) ifTrue:[ self error: 'high surrogate expected' ].
+	(self isHighSurrogate: value)
+		ifTrue: [
+			| lowSurrogate |
+			self expectChar: $\.
+			self expectChar: $u.
+			lowSurrogate := self parseCharacterHexRaw.
+			(self isLowSurrogate: lowSurrogate) ifFalse: [
+				^ self error: 'low surrogate expected' ].
+			value := self createCodePointFromSurrogatesHigh: value low: lowSurrogate ]
+		ifFalse: [
+			(self isLowSurrogate: value)
+				ifTrue: [ self error: 'unexpected low surrogate' ] ].
 	^ Character codePoint: value

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
@@ -9,7 +9,6 @@ parseCharacterHex
 		lowSurrogate := self parseCharacterHexRaw.
 		(self isLowSurrogate: lowSurrogate) ifFalse: [
 			^ self error: 'low surrogate expected' ].
-		value := 16r10000 +
-			((value - 16rD800 bitShift: 10)
-			bitOr: (lowSurrogate - 16rDC00)) ].
+		value := 16r10000 + ((value - 16rD800 bitShift: 10) bitOr: (lowSurrogate - 16rDC00)) ].
+	(self isLowSurrogate: value) ifTrue:[ self error: 'high surrogate expected' ].
 	^ Character codePoint: value

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHex.st
@@ -1,6 +1,15 @@
 parsing-internal
 parseCharacterHex
 	| value |
-	value := self parseCharacterHexDigit.
-	3 timesRepeat: [ value := (value << 4) + self parseCharacterHexDigit ].
+	value := self parseCharacterHexRaw.
+	(self isHighSurrogate: value) ifTrue: [
+		| lowSurrogate |
+		self expectChar: $\.
+		self expectChar: $u.
+		lowSurrogate := self parseCharacterHexRaw.
+		(self isLowSurrogate: lowSurrogate) ifFalse: [
+			^ self error: 'low surrogate expected' ].
+		value := 16r10000 +
+			((value - 16rD800 bitShift: 10)
+			bitOr: (lowSurrogate - 16rDC00)) ].
 	^ Character codePoint: value

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHexRaw.st
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/instance/parseCharacterHexRaw.st
@@ -1,0 +1,6 @@
+parsing-internal
+parseCharacterHexRaw
+	| value |
+	value := self parseCharacterHexDigit.
+	3 timesRepeat: [ value := (value << 4) + self parseCharacterHexDigit ].
+	^ value

--- a/repository/Seaside-JSON-Core.package/WAJsonParser.class/properties.json
+++ b/repository/Seaside-JSON-Core.package/WAJsonParser.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "lr 12/31/2009 23:56",
+	"commentStamp" : "pmm 8/31/2022 15:08",
 	"super" : "WAObject",
 	"category" : "Seaside-JSON-Core-Parser",
 	"classinstvars" : [ ],

--- a/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/supportsEmoji.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/supportsEmoji.st
@@ -1,0 +1,8 @@
+utilities
+supportsEmoji
+	^ [ String
+			with: (Character codePoint: 16r1F1F3) "Regional Indicator Symbol Letter N"
+			with: (Character codePoint: 16r1F1F1). "Regional Indicator Symbol Letter L"
+		true ]
+		on: Error
+		do: [ :error | false ]

--- a/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testNonBmpCodePoints.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testNonBmpCodePoints.st
@@ -4,9 +4,9 @@ testNonBmpCodePoints
 	self supportsEmoji ifFalse: [
 		^ self ].
 	
-	"duch flag as two surrogate pairs"
+	"dutch flag as two surrogate pairs"
 	parsed := self parse: '"\uD83C\uDDF3\uD83C\uDDF1"'.
 
 	self assert: parsed size = 2.
 	self assert: parsed first codePoint = 16r1F1F3. "Regional Indicator Symbol Letter N"
-	self assert: parsed second codePoint = 16r1F1F1 "Regional Indicator Symbol Letter l"
+	self assert: parsed second codePoint = 16r1F1F1 "Regional Indicator Symbol Letter L"

--- a/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testNonBmpCodePoints.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testNonBmpCodePoints.st
@@ -1,0 +1,12 @@
+tests-literals
+testNonBmpCodePoints
+	| parsed |
+	self supportsEmoji ifFalse: [
+		^ self ].
+	
+	"duch flag as two surrogate pairs"
+	parsed := self parse: '"\uD83C\uDDF3\uD83C\uDDF1"'.
+
+	self assert: parsed size = 2.
+	self assert: parsed first codePoint = 16r1F1F3. "Regional Indicator Symbol Letter N"
+	self assert: parsed second codePoint = 16r1F1F1 "Regional Indicator Symbol Letter l"

--- a/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testSurrogatePairs.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testSurrogatePairs.st
@@ -1,7 +1,7 @@
 tests-invalid
 testSurrogatePairs
-	"Tests JSJsonParser, in particular the handling of \uXXXX\uXXXX sequences that
-	form surrogate pairs (see: https://tools.ietf.org/html/rfc7159#section-7)."
+	"Tests the handling of \uXXXX\uXXXX sequences that form surrogate pairs
+	(see: https://www.rfc-editor.org/rfc/rfc8259#section-7)."
 
 	self assert: (WAJsonParser parse: '"\uD800\uDC00"') equals: (String with: (Character codePoint: 16r10000)).
 	self assert: (WAJsonParser parse: '"\uD834\uDD1E"') equals: (String with: (Character codePoint: 16r1D11E)).

--- a/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testSurrogatePairs.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonParserTest.class/instance/testSurrogatePairs.st
@@ -1,0 +1,21 @@
+tests-invalid
+testSurrogatePairs
+	"Tests JSJsonParser, in particular the handling of \uXXXX\uXXXX sequences that
+	form surrogate pairs (see: https://tools.ietf.org/html/rfc7159#section-7)."
+
+	self assert: (WAJsonParser parse: '"\uD800\uDC00"') equals: (String with: (Character codePoint: 16r10000)).
+	self assert: (WAJsonParser parse: '"\uD834\uDD1E"') equals: (String with: (Character codePoint: 16r1D11E)).
+	self assert: (WAJsonParser parse: '"\uDBFF\uDFFF"') equals: (String with: (Character codePoint: 16r10FFFF)).
+	self assert: (WAJsonParser parse: '"\uD7FF\uD800\uDC00\uE000"') equals:
+		(String with: (Character codePoint: 16rD7FF) with: (Character codePoint: 16r10000) with: (Character codePoint: 16rE000)).
+
+	self should: [ WAJsonParser parse: '"\uD800"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uDEAD"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uDBFF"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uDC00"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uDFFF"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uD800\uDBFF"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uD800\uE000"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uD800\DC00"' ] raise: WAJsonSyntaxError.
+	self should: [ WAJsonParser parse: '"\uD800DC00"' ] raise: WAJsonSyntaxError.
+


### PR DESCRIPTION
Fixes #1340