### PR TITLE
Modifies WAServerManager to support subclasses to be defined as default

### DIFF
--- a/repository/Seaside-Core.package/WAServerManager.class/class/beDefault.st
+++ b/repository/Seaside-Core.package/WAServerManager.class/class/beDefault.st
@@ -1,0 +1,5 @@
+configuring
+beDefault
+	"Set an instance of receiver to be the default Server Manager."
+	
+	Default contents: self new

--- a/repository/Seaside-Core.package/WAServerManager.class/class/beDefault.st
+++ b/repository/Seaside-Core.package/WAServerManager.class/class/beDefault.st
@@ -2,4 +2,4 @@ configuring
 beDefault
 	"Set an instance of receiver to be the default Server Manager."
 	
-	Default contents: self new
+	self setDefault: self new

--- a/repository/Seaside-Core.package/WAServerManager.class/class/default.st
+++ b/repository/Seaside-Core.package/WAServerManager.class/class/default.st
@@ -1,4 +1,6 @@
 accessing
 default
-	default contents ifNil: [ default contents: self new ].
-	^ default contents
+
+	self initializeDefaultValueHolder.
+	Default contents ifNil: [ Default contents: self new ].
+	^ Default contents

--- a/repository/Seaside-Core.package/WAServerManager.class/class/initializeDefaultValueHolder.st
+++ b/repository/Seaside-Core.package/WAServerManager.class/class/initializeDefaultValueHolder.st
@@ -1,4 +1,4 @@
 class initialization
 initializeDefaultValueHolder
-	default isNil ifTrue: [ 
-		default := GRPlatform current newTransientValueHolder ]
+	Default isNil ifTrue: [ 
+		Default := GRPlatform current newTransientValueHolder ]

--- a/repository/Seaside-Core.package/WAServerManager.class/class/setDefault..st
+++ b/repository/Seaside-Core.package/WAServerManager.class/class/setDefault..st
@@ -1,0 +1,6 @@
+configuring
+setDefault: aWAServerManager
+	"Private - Sets aWAServerManager as the default instance of receiver."
+
+	self initializeDefaultValueHolder.
+	Default contents: aWAServerManager.

--- a/repository/Seaside-Core.package/WAServerManager.class/properties.json
+++ b/repository/Seaside-Core.package/WAServerManager.class/properties.json
@@ -2,11 +2,11 @@
 	"commentStamp" : "TorstenBergmann 9/18/2021 23:06",
 	"super" : "WAObject",
 	"category" : "Seaside-Core-Server",
-	"classinstvars" : [
-		"default"
-	],
+	"classinstvars" : [ ],
 	"pools" : [ ],
-	"classvars" : [ ],
+	"classvars" : [
+		"Default"
+	],
 	"instvars" : [
 		"adaptors"
 	],

--- a/repository/Seaside-Tests-Core.package/WAServerManagerTest.class/instance/testBeDefault.st
+++ b/repository/Seaside-Tests-Core.package/WAServerManagerTest.class/instance/testBeDefault.st
@@ -1,0 +1,13 @@
+tests
+testBeDefault
+
+	| previous |
+	previous := WAServerManager default.
+	[ 
+    	WATestServerManager beDefault.
+    	self
+		  assert: WAServerManager default class
+		  equals: WATestServerManager
+	 ] ensure: [ 
+		WAServerManager setDefault: previous 
+	 ]

--- a/repository/Seaside-Tests-Core.package/WAServerManagerTest.class/instance/testSetDefault.st
+++ b/repository/Seaside-Tests-Core.package/WAServerManagerTest.class/instance/testSetDefault.st
@@ -1,0 +1,13 @@
+tests
+testSetDefault
+
+	| previous |
+	previous := WAServerManager default.
+	[ 
+		WAServerManager setDefault: WATestServerManager new.
+		self
+			assert: WAServerManager default class
+			equals: WATestServerManager
+	] ensure: [ 
+		WAServerManager setDefault: previous
+	]

--- a/repository/Seaside-Tests-Core.package/WATestServerManager.class/README.md
+++ b/repository/Seaside-Tests-Core.package/WATestServerManager.class/README.md
@@ -1,0 +1,1 @@
+I am a server manager used as an alternative of the WAServerManager, because some Smalltalk dialects have subclasses of WAServerManager.

--- a/repository/Seaside-Tests-Core.package/WATestServerManager.class/properties.json
+++ b/repository/Seaside-Tests-Core.package/WATestServerManager.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "EstebanMaringolo 9/13/2022 16:08",
+	"super" : "WAServerManager",
+	"category" : "Seaside-Tests-Core-Server",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WATestServerManager",
+	"type" : "normal"
+}


### PR DESCRIPTION
VAST, and probably other dialects, have a subclass of WAServerManager that is used instead of it.

Since `WAServerManager[default]` is a class instance variable, then sending the message `default` to `WAServerManager` will always answer an instance of itself. Which is more troubling if you access it by means of `WAAdmin defaultServerManager`.

This PR modifies the `default` class instance variable to be a class variable (named `Default`), and provides a `beDefault` method that can be used on subclasses to be the "singleton" default.

