### PR TITLE
JQAutocomplete (follow-up to issue #1232): content-type for json call…

### DIFF
--- a/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/instance/renderContentOn..st
@@ -1,10 +1,33 @@
 rendering
 renderContentOn: html
-	html label
-		for: html nextId;
-		with: 'Type a Seaside package name:'.
-	html break.
-	html textInput
-		id: html lastId;
-		script: (html jQuery this autocomplete
-			sourceCallback: [ :term | self packageNamesFor: term ])
+
+	| showId |
+	showId := html nextId.
+	
+	html paragraph: [
+		html label
+			for: html nextId;
+			with: 'Type a Seaside package name (no callback):'.
+		html break.
+		html textInput
+			id: html lastId;
+			script: (html jQuery this autocomplete sourceCallback: [ :term |
+						 self packageNamesFor: term ]) ].
+
+	html paragraph: [
+		html label
+			for: html nextId;
+			with: 'Type a Seaside package name (with callback):'.
+		html break.
+		html textInput
+			id: html lastId;
+			script: (html jQuery this autocomplete
+					 search: [ :term | self packageNamesFor: term ]
+					 labels: [ :packagename | packagename ]
+					 callback: [ :val :s |
+						 selectedPackageName := val.
+						 s << (s jQuery id: showId) html: [ :r | self renderSelectedPackageNameOn: r ] ]).
+		html break.
+		html div
+			id: showId;
+			with: [ self renderSelectedPackageNameOn: html ] ]

--- a/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/instance/renderSelectedPackageNameOn..st
+++ b/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/instance/renderSelectedPackageNameOn..st
@@ -1,0 +1,6 @@
+rendering
+renderSelectedPackageNameOn: html
+
+	html text: (selectedPackageName
+			 ifNil: [ 'No package name selected' ]
+			 ifNotNil: [ selectedPackageName , ' was selected' ])

--- a/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/properties.json
+++ b/repository/JQuery-Tests-UI.package/JQAutocompleteFunctionalTest.class/properties.json
@@ -6,7 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"packages"
+		"packages",
+		"selectedPackageName"
 	],
 	"name" : "JQAutocompleteFunctionalTest",
 	"type" : "normal"

--- a/repository/JQuery-UI.package/JQAutocomplete.class/instance/search.callback..st
+++ b/repository/JQuery-UI.package/JQAutocomplete.class/instance/search.callback..st
@@ -1,3 +1,4 @@
 convenience
 search: aSearchBlock callback: aCallbackBlock
+
 	self search: aSearchBlock labels: [ :each | each greaseString ] callback: aCallbackBlock

--- a/repository/JQuery-UI.package/JQAutocomplete.class/instance/search.labels.callback..st
+++ b/repository/JQuery-UI.package/JQAutocomplete.class/instance/search.labels.callback..st
@@ -4,18 +4,19 @@ search: aSearchBlock labels: aLabelsBlock callback: aCallbackBlock
 	
 	| term mapping |
 	mapping := IdentityDictionary new.
-	"assigments to temps don't work in GS 2.4'
+	"Use a WAValueHolder because assigments to temps don't work in GemStone.
 	http://code.google.com/p/glassdb/issues/detail?id=221"
 	term := WAValueHolder new.
 	self source: ((self jQuery getJson
 		callback: [ :value | term contents: value ]
 		value: (JSStream on: 'request.term');
-		text: [ :stream | 
-			stream json: ((aSearchBlock value: term contents) asArray collect: [ :object | 
-				GRSmallDictionary2 new
-					at: 'label' put: (aLabelsBlock value: object);
-					at: 'index' put: (mapping at: object ifAbsentPut: [ mapping size + 1 ]);
-					yourself ]) ];
+		json: [ :json | 
+			json array: [
+				(aSearchBlock value: term contents) do: [ :object | 
+					json object: [ 
+						json 
+							key: 'label' value: (aLabelsBlock value: object);
+							key: 'index' value: (mapping at: object ifAbsentPut: [ mapping size + 1 ]) ] ] ] ];
 		onSuccess: 'response(arguments[0])'; 
 		dataType: 'jsonp') asFunction: #('request' 'response')).
 	self onSelect: ((self jQuery ajax

--- a/repository/JQuery-UI.package/JQAutocomplete.class/instance/sourceCallback..st
+++ b/repository/JQuery-UI.package/JQAutocomplete.class/instance/sourceCallback..st
@@ -7,7 +7,7 @@ sourceCallback: aOneArgumentBlock
 	http://code.google.com/p/glassdb/issues/detail?id=152"
 	term := WAValueHolder new.
 	self source: ((self jQuery getJson
-		json: [ :stream | stream value: (aOneArgumentBlock value: term contents) ];
+		json: [ :json | json value: (aOneArgumentBlock value: term contents) ];
 		callback: [ :value | term contents: value ] value: (JSStream on: 'request.term');
 		onSuccess: 'response(arguments[0])'; 
 		dataType: 'jsonp') asFunction: #('request' 'response'))


### PR DESCRIPTION
…back in jQueryUI autocompleter should be application/json and not text/plain. Reworked the callback implementation to no longer create intermediate objects for serialization to json but use the json canvas directly.