### PR TITLE
Deprecated html tags

### DIFF
--- a/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/charset..st
+++ b/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/charset..st
@@ -1,5 +1,7 @@
 attributes
 charset: aString
 	"This attribute specifies the character encoding of the resource designated by the link."
-	
+	self
+		greaseDeprecatedApi: 'WAAnchorTag>>charset:'
+		details: 'Use an HTTP Content-Type header on the linked resource instead. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.	
 	self attributes at: 'charset' put: aString

--- a/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/name..st
+++ b/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/name..st
@@ -1,5 +1,7 @@
 attributes
 name: aString
 	"This attribute names the current anchor so that it may be the destination of another link. The value of this attribute must be a unique anchor name. The scope of this name is the current document. Note that this attribute shares the same name space as the id attribute."
-
+	self
+		greaseDeprecatedApi: 'WAAnchorTag>>name:'
+		details: 'Use the id attribute instead. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.	
 	self attributes at: 'name' put: aString

--- a/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/reverse..st
+++ b/repository/Seaside-Canvas.package/WAAnchorTag.class/instance/reverse..st
@@ -1,5 +1,7 @@
 attributes
 reverse: aString
 	"This attribute is used to describe a reverse link from the anchor specified by the href attribute to the current document. The value of this attribute is a space-separated list of link types."
-	
+	self
+		greaseDeprecatedApi: 'WAAnchorTag>>reverse:'
+		details: 'Use the rel attribute. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.		
 	self attributes at: 'rev' append: aString

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/acronym..st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/acronym..st
@@ -1,3 +1,3 @@
-tags-block
+tags-deprecated
 acronym: aBlock
 	self acronym with: aBlock

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/acronym.st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/acronym.st
@@ -1,5 +1,7 @@
-tags-block
+tags-deprecated
 acronym
 	"Defines an acronym, such as 'GmbH', 'NATO', and 'F.B.I.'"
-
+	self
+		greaseDeprecatedApi: 'WAHtmlCanvas>>acronym'
+		details: 'https://www.w3docs.com/learn-html/deprecated-html-tags.html'.
 	^ self tag: 'acronym'

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/big..st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/big..st
@@ -1,3 +1,3 @@
-tags-format
+tags-deprecated
 big: aBlock
 	self big with: aBlock

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/big.st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/big.st
@@ -1,5 +1,7 @@
-tags-format
+tags-deprecated
 big
 	"Defines big text."
-
+	self
+		greaseDeprecatedApi: 'WAHtmlCanvas>>big'
+		details: 'https://www.w3docs.com/learn-html/deprecated-html-tags.html'.
 	^ self tag: 'big'

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/embed..st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/embed..st
@@ -1,3 +1,3 @@
-tags
+tags-deprecated
 embed: aBlock
 	self embed with: aBlock

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/embed.st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/embed.st
@@ -1,4 +1,7 @@
-tags
+tags-deprecated
 embed
 	"The embed element represents an integration point for an external (typically non-HTML) application or interactive content."
+	self
+		greaseDeprecatedApi: 'WAHtmlCanvas>>embed'
+		details: 'https://www.w3docs.com/learn-html/deprecated-html-tags.html'.
 	^ self brush: WAEmbedTag new

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/menu..st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/menu..st
@@ -1,3 +1,3 @@
-tags
+tags-deprecated
 menu: aBlock
 	self menu with: aBlock

--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/menu.st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/menu.st
@@ -1,3 +1,6 @@
-tags
+tags-deprecated
 menu
+	self
+		greaseDeprecatedApi: 'WAHtmlCanvas>>menu'
+		details: 'https://www.w3docs.com/learn-html/deprecated-html-tags.html'.
 	^ self brush: WAMenuTag new

--- a/repository/Seaside-Canvas.package/WATableCellTag.class/instance/align..st
+++ b/repository/Seaside-Canvas.package/WATableCellTag.class/instance/align..st
@@ -7,5 +7,8 @@ align: aString
 - right: Right-flush data/Right-justify text.
 - justify: Double-justify text.
 - char: Align text around a specific character. If a user agent doesn't support character alignment, behavior in - the presence of this value is unspecified."
+	self
+		greaseDeprecatedApi: 'WATableCellTag>>align:'
+		details: 'Not supported in html5. https://www.w3docs.com/learn-html/html-td-tag.html'.	
 
 	self attributes at: 'align' put: aString

--- a/repository/Seaside-Canvas.package/WATableCellTag.class/instance/character..st
+++ b/repository/Seaside-Canvas.package/WATableCellTag.class/instance/character..st
@@ -1,5 +1,7 @@
 attributes
 character: aString
 	"This attribute specifies a single character within a text fragment to act as an axis for alignment. The default value for this attribute is the decimal point character for the current language as set by the lang attribute. User agents are not required to support this attribute."
-	
+	self
+		greaseDeprecatedApi: 'WATableCellTag>>character:'
+		details: 'Not supported in html5. https://www.w3docs.com/learn-html/html-td-tag.html'.	
 	self attributes at: 'char' put: aString

--- a/repository/Seaside-Canvas.package/WATableCellTag.class/instance/characterOffset..st
+++ b/repository/Seaside-Canvas.package/WATableCellTag.class/instance/characterOffset..st
@@ -1,5 +1,7 @@
 attributes
 characterOffset: anInteger
 	"When present, this attribute specifies the offset to the first occurrence of the alignment character on each line. If a line doesn't include the alignment character, it should be horizontally shifted to end at the alignment position."
-
+	self
+		greaseDeprecatedApi: 'WATableCellTag>>characterOffset:'
+		details: 'Not supported in html5. https://www.w3docs.com/learn-html/html-td-tag.html'.	
 	self attributes at: 'charoff' put: anInteger

--- a/repository/Seaside-Canvas.package/WATableDataTag.class/instance/abbreviation..st
+++ b/repository/Seaside-Canvas.package/WATableDataTag.class/instance/abbreviation..st
@@ -1,5 +1,7 @@
 attributes
 abbreviation: aString
 	"This attribute should be used to provide an abbreviated form of the cell's content, and may be rendered by user agents when appropriate in place of the cell's content. Abbreviated names should be short since user agents may render them repeatedly. For instance, speech synthesizers may render the abbreviated headers relating to a particular cell before rendering that cell's content."
-	
+	self
+		greaseDeprecatedApi: 'WATableDateTag>>abbreviation:'
+		details: 'Use text that begins in an unambiguous and terse manner, and include any more elaborate text after that. https://www.w3docs.com/learn-html/html-td-tag.html'.		
 	self attributes at: 'abbr' put: aString

--- a/repository/Seaside-Canvas.package/WATableDataTag.class/instance/axis..st
+++ b/repository/Seaside-Canvas.package/WATableDataTag.class/instance/axis..st
@@ -1,5 +1,7 @@
 attributes
 axis: aString
 	"This attribute may be used to place a cell into conceptual categories that can be considered to form axes in an n-dimensional space. User agents may give users access to these categories (e.g., the user may query the user agent for all cells that belong to certain categories, the user agent may present a table in the form of a table of contents, etc.). Please consult the section on categorizing cells for more information. The value of this attribute is a comma-separated list of category names."
-	
+	self
+		greaseDeprecatedApi: 'WATableDateTag>>axis:'
+		details: 'Not supported in html5. https://www.w3docs.com/learn-html/html-td-tag.html'.		
 	self attributes at: 'axis' put: aString

--- a/repository/Seaside-Canvas.package/WATableDataTag.class/instance/scope..st
+++ b/repository/Seaside-Canvas.package/WATableDataTag.class/instance/scope..st
@@ -6,5 +6,7 @@ scope: aString
 - col: The current cell provides header information for the rest of the column that contains it.
 - rowgroup: The header cell provides header information for the rest of the row group that contains it.
 - colgroup: The header cell provides header information for the rest of the column group that contains it."
-
+	self
+		greaseDeprecatedApi: 'WATableDateTag>>scope:'
+		details: 'Not supported in html5. https://www.w3docs.com/learn-html/html-td-tag.html'.		
 	self attributes at: 'scope' put: aString

--- a/repository/Seaside-Core.package/WAContentElement.class/instance/charset..st
+++ b/repository/Seaside-Core.package/WAContentElement.class/instance/charset..st
@@ -1,3 +1,6 @@
 attributes
 charset: aString
+	self
+		greaseDeprecatedApi: 'WAContentElement>>charset:'
+		details: 'Use an HTTP Content-Type header on the linked resource instead. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.	
 	self attributeAt: 'charset' put: aString

--- a/repository/Seaside-Core.package/WALinkElement.class/instance/reverse..st
+++ b/repository/Seaside-Core.package/WALinkElement.class/instance/reverse..st
@@ -1,4 +1,7 @@
 attributes
 reverse: aString
 	"This attribute is used to describe a reverse link from the anchor specified by the href attribute to the current document. The value of this attribute is a space-separated list of link types."
+	self
+		greaseDeprecatedApi: 'WALinkElement>>reverse:'
+		details: 'Use the rel attribute. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.	
 	self attributeAt: 'rev' put: aString

--- a/repository/Seaside-Core.package/WAMetaElement.class/instance/charset..st
+++ b/repository/Seaside-Core.package/WAMetaElement.class/instance/charset..st
@@ -5,5 +5,7 @@ charset: aString
 The charset attribute on the meta element has no effect in XML documents, and is only allowed in order to facilitate migration to and from XHTML.
 
 There must not be more than one meta element with a charset attribute per document."
-	
+	self
+		greaseDeprecatedApi: 'WAMetaElement>>charset:'
+		details: 'Use an HTTP Content-Type header on the linked resource instead. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.
 	self attributes at: 'charset' put: aString

--- a/repository/Seaside-Core.package/WAMetaElement.class/instance/scheme..st
+++ b/repository/Seaside-Core.package/WAMetaElement.class/instance/scheme..st
@@ -1,3 +1,6 @@
 attributes
 scheme: aString
+	self
+		greaseDeprecatedApi: 'WAMetaElement>>scheme:'
+		details: 'Use only one scheme per field, or make the scheme declaration part of the value. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.	
 	self attributeAt: 'scheme' put: aString


### PR DESCRIPTION
Mark the html tags and attributes that have been deprecated/removed in html5 as deprecated in Seaside