### PR TITLE
Fix #initializeFromString: in WAUrl to take into account that ‘://’ can also be included in the query

### DIFF
--- a/repository/Seaside-Core.package/WAUrl.class/instance/initializeFromString..st
+++ b/repository/Seaside-Core.package/WAUrl.class/instance/initializeFromString..st
@@ -16,7 +16,7 @@ initializeFromString: aString
 			to: (fragmentIndex = 0 ifTrue: [ stringSize + 1 ] ifFalse: [ fragmentIndex ]) ].
 	schemeIndex := aString indexOfSubCollection: '://'.
 	
-	(schemeIndex > 0 and: [ fragmentIndex = 0 or: [ schemeIndex < fragmentIndex ] ])
+	(schemeIndex > 0 and: [ (fragmentIndex = 0 or: [ schemeIndex < fragmentIndex ]) and: [ queryIndex = 0 or: [ schemeIndex < queryIndex ] ] ])
 		ifTrue: [
 			startWithPath := false.
 			self scheme: (aString copyFrom: 1 to: schemeIndex - 1).

--- a/repository/Seaside-Tests-Core.package/WAUrlTest.class/instance/testNastyEdgeCasesParsing.st
+++ b/repository/Seaside-Tests-Core.package/WAUrlTest.class/instance/testNastyEdgeCasesParsing.st
@@ -9,6 +9,11 @@ testNastyEdgeCasesParsing
 		decodedWith: GRNullCodec new.
 	self assert: url path first = 'blue/red?and+green'.
 	
+	url := WAUrl absolute: '/blue?http://example.com/red'.
+	self assert: url path = (OrderedCollection with: 'blue').
+	self assert: url queryFields keys = #('http://example.com/red').
+	self assert: url queryFields values = #(nil).
+	
 	url := (WAUrl absolute: 'http://example.com/:@-._~!$&''()*+,=;:@-._~!$&''()*+,=:@-._~!$&''()*+,==?/?:@-._~!$''()*+,;=/?:@-._~!$''()*+,;==#/?:@-._~!$&''()*+,;=')
 		decodedWith: GRNullCodec new.
 	self assert: url path first = ':@-._~!$&''()*+,='.


### PR DESCRIPTION
This pull request fixes issue #1376 by making `#initializeFromString:` in WAUrl take into account that `://` can also be included in the query.

The example this pull request adds to `#testNastyEdgeCasesParsing` reflects the use of `#absolute:` in `#requestUrlFor:` in WAFastCGIRequestConverter: the argument to `#absolute:` is not a valid absolute URI as defined in [section 4.3 in RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-4.3), as it does not begin with a scheme, but it is a valid request target as defined in [section 3.2 in RFC 9112](https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2). WAUrl and WAFastCGIRequestConverter should maybe be made to better distinguish between those.