### PR TITLE
Fix #requestHeadersFor: on ZnZincServerAdaptor to combine field values for repeated field names

### DIFF
--- a/repository/Zinc-Seaside.package/ZnZincServerAdaptor.class/instance/requestHeadersFor..st
+++ b/repository/Zinc-Seaside.package/ZnZincServerAdaptor.class/instance/requestHeadersFor..st
@@ -3,5 +3,10 @@ requestHeadersFor: aZincRequest
 	| fields |
 	fields := Dictionary new.
 	aZincRequest headersDo: [ :key :value |
-		fields at: key asLowercase put: value ].
+		| keyLowercase combinedValue |
+		keyLowercase := key asLowercase.
+		combinedValue := fields at: keyLowercase
+			ifPresent: [ :presentValue | presentValue , ',' , value ]
+			ifAbsent: [ value ].
+		fields at: keyLowercase put: combinedValue ].
 	^ fields


### PR DESCRIPTION
This pull request fixes `#requestHeadersFor:` on ZnZincServerAdaptor to combine field values for repeated header field names.

[Section ‘5.2. Field Lines and Combined Field Value’ in RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2) states:

> When a field name is only present once in a section, the combined "field value" for that field consists of the corresponding field line value. When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.

See also [section ‘6.3. Header Fields’](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.3).

Example:

```smalltalk
request := String crlf join: #('GET / HTTP/1.1'
	'Accept: application/xml'
	'Accept: application/json'
	'' '').
(ZnZincServerAdaptor new requestFor: (ZnRequest readFromString: request))
	headerAt: 'accept'
```

Without this fix, the example returns `'application/json'`.
With this fix, the example returns `'application/xml,application/json'`.