### PR TITLE
Update UTF-8 sampler link

### DIFF
--- a/repository/Seaside-Tests-Functional.package/WAEncodingFunctionalTest.class/instance/renderExplanationOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAEncodingFunctionalTest.class/instance/renderExplanationOn..st
@@ -4,7 +4,7 @@ renderExplanationOn: html
 		html listItem: [
 			html text: 'Go to the '.
 			html anchor
-				url: 'http://www.columbia.edu/kermit/utf8.html';
+				url: 'https://www.kermitproject.org/utf8.html';
 				with: 'UTF-8 Sampler'.
 			html text: ' and select some "foreign" text.' ].
 		html listItem: 'Copy and paste it into the urlencoded text field below and click the submit button.'.


### PR DESCRIPTION
The UTF-8 sampler moved to a new location, updates the functional test to point there