### PR TITLE
update z-index of wa-toolbar to 99999

### DIFF
--- a/repository/Seaside-Development.package/WADevelopmentFiles.class/instance/developmentCss.st
+++ b/repository/Seaside-Development.package/WADevelopmentFiles.class/instance/developmentCss.st
@@ -6,7 +6,7 @@ body { margin-bottom: 25px !important; /*matches toolbar min-height + padding an
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: 20;
+	z-index: 99999;
 	padding: 2px;
 	position: fixed;
 	text-align: left;


### PR DESCRIPTION
There are frameworks that place content at z-index 1000+ and light-boxes that place their content at z-index 10000.

To ensure that the WAToolbar always sits in front of other content, I always set it to a silly big number.

I thought this may be handy for others as well.