### PR TITLE
Fix browser on Pharo 13

### DIFF
--- a/repository/Seaside-Pharo-Development.package/WARPackageBasedBrowser.class/instance/packages.st
+++ b/repository/Seaside-Pharo-Development.package/WARPackageBasedBrowser.class/instance/packages.st
@@ -1,7 +1,10 @@
 private
 packages
-	| rPackage |
-	rPackage := Smalltalk at: #RPackage.
-	^ ((rPackage respondsTo: #packageOrganizer)
-		ifTrue: [ rPackage packageOrganizer ]
-		ifFalse: [ rPackage organizer ]) packages
+	^ (Smalltalk hasClassNamed: #RPackage)
+		ifTrue: [ 
+			| rPackage |
+			rPackage := Smalltalk at: #RPackage.
+			((rPackage respondsTo: #packageOrganizer)
+				ifTrue: [ rPackage packageOrganizer ]
+				ifFalse: [ rPackage organizer ]) packages  ]
+		ifFalse: [ PackageOrganizer default packages ]

--- a/repository/Seaside-Pharo-Development.package/WARPackageBasedBrowser.class/instance/parentOfClass..st
+++ b/repository/Seaside-Pharo-Development.package/WARPackageBasedBrowser.class/instance/parentOfClass..st
@@ -7,7 +7,9 @@ parentOfClass: aClass
 	| package tag |
 	
 	package := aClass package.
-	tag := package classTagForClass: aClass.
+	tag := (package respondsTo: #classTagForClass:)
+		ifTrue: [ package perform: #classTagForClass: with: aClass ]
+		ifFalse: [ package perform: #tagOf: with: aClass ].
 	
 	^ (((tag name = package name) and: [ package classTags size <= 1 ]) or: [ tag isNil ])
 		ifTrue: [ package ]


### PR DESCRIPTION
Deal with the removal of `RPackage` and `#classTagForClass` being renamed to `#tagOf:`