### PR TITLE
Fix MCWorkingCopy deprecations

### DIFF
--- a/repository/Seaside-Pharo-Tools-Web.package/WASeasideVersionStatus.class/instance/sortedWorkingCopies.st
+++ b/repository/Seaside-Pharo-Tools-Web.package/WASeasideVersionStatus.class/instance/sortedWorkingCopies.st
@@ -3,7 +3,10 @@ sortedWorkingCopies
 	| categories packageNames workingCopies |
 	categories := Dictionary new.
 	packageNames := GRPackage grPackages collect: [ :each | each name ].
-	workingCopies := MCWorkingCopy allManagers select: [ :each | packageNames includes: each packageName ].
+	workingCopies := ((MCWorkingCopy respondsTo: #allWorkingCopies)
+		ifTrue: [ MCWorkingCopy allWorkingCopies ]
+		ifFalse: [ MCWorkingCopy allManagers ])
+			select: [ :each | packageNames includes: each packageName ].
 	workingCopies do: 
 		[ :each | 
 		| category |

--- a/repository/Seaside-Pharo-Tools-Web.package/monticello.meta/categories.st
+++ b/repository/Seaside-Pharo-Tools-Web.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Seaside-Pharo-Tools-Web'!
+self packageOrganizer ensurePackage: #'Seaside-Pharo-Tools-Web' withTags: #()!


### PR DESCRIPTION
Send #allWorkingCopies instead of  #allManagers to MCWorkingCopy if available.

`WASeasideVersionStatus` now renders with the only deprecated message being `WAMetaElement>>charset:`.

![WASeasideVersionStatus](https://github.com/user-attachments/assets/fe9c2480-d30b-45de-b331-4c612ed4f1c2)
