### PR TITLE
Fix html deprecations

### DIFF
--- a/repository/Seaside-Canvas.package/WATableHeadingTag.class/instance/scope..st
+++ b/repository/Seaside-Canvas.package/WATableHeadingTag.class/instance/scope..st
@@ -1,0 +1,10 @@
+attributes
+scope: aString
+	"This attribute specifies the set of data cells for which the current header cell provides header information. This attribute may be used in place of the headers attribute, particularly for simple tables. When specified, this attribute must have one of the following values:
+
+- row: The current cell provides header information for the rest of the row that contains it (see also the section on table directionality).
+- col: The current cell provides header information for the rest of the column that contains it.
+- rowgroup: The header cell provides header information for the rest of the row group that contains it.
+- colgroup: The header cell provides header information for the rest of the column group that contains it."
+
+	self attributes at: 'scope' put: aString

--- a/repository/Seaside-Core.package/WAMetaElement.class/instance/charset..st
+++ b/repository/Seaside-Core.package/WAMetaElement.class/instance/charset..st
@@ -5,7 +5,4 @@ charset: aString
 The charset attribute on the meta element has no effect in XML documents, and is only allowed in order to facilitate migration to and from XHTML.
 
 There must not be more than one meta element with a charset attribute per document."
-	self
-		greaseDeprecatedApi: 'WAMetaElement>>charset:'
-		details: 'Use an HTTP Content-Type header on the linked resource instead. https://www.geeksforgeeks.org/what-are-the-html-tags-that-deprecated-in-html5/'.
 	self attributes at: 'charset' put: aString

--- a/repository/Seaside-Tests-Canvas.package/WACanvasBrushTest.class/instance/testTableData.st
+++ b/repository/Seaside-Tests-Canvas.package/WACanvasBrushTest.class/instance/testTableData.st
@@ -20,7 +20,4 @@ testTableData
 		gives: '<td colspan="2" rowspan="3"></td>'.
 	self
 		assert: [ :html | html tableData headers: 'zork' ]
-		gives: '<td headers="zork"></td>'.
-	self
-		assert: [ :html | html tableData scope: 'colgroup' ]
-		gives: '<td scope="colgroup"></td>'
+		gives: '<td headers="zork"></td>'

--- a/repository/Seaside-Tests-Canvas.package/monticello.meta/categories.st
+++ b/repository/Seaside-Tests-Canvas.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Seaside-Tests-Canvas'!
+self packageOrganizer ensurePackage: #'Seaside-Tests-Canvas' withTags: #()!

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderCurrencyTableBodyOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderCurrencyTableBodyOn..st
@@ -9,9 +9,5 @@ renderCurrencyTableBodyOn: html
             do: [ :each | 
               html
                 tableRow: [ 
-                  html tableHeading: each first.	"https://bugzilla.mozilla.org/show_bug.cgi?id=2212
-					https://bugzilla.mozilla.org/show_bug.cgi?id=915"
-                  html tableData
-                    align: 'char';
-                    character: $.;
-                    with: (numberPrinter print: each second) ] ] ]
+                  html tableHeading: each first.
+                  html tableData: (numberPrinter print: each second) ] ] ]

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderCurrencyTableOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderCurrencyTableOn..st
@@ -5,6 +5,6 @@ renderCurrencyTableOn: html
 		with: [
 			html tableCaption: 'Currencies against Swiss Franc (CHF)'.
 			html tableColumnGroup.
-			html tableColumnGroup width: '100px'; align: 'char'; character: $..
+			html tableColumnGroup.
 			self renderCurrencyTableHeadOn: html.
 			self renderCurrencyTableBodyOn: html ]

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableBodyOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableBodyOn..st
@@ -8,5 +8,6 @@ renderEntityTableBodyOn: html
 				eachEntity second do: [ :each |
 					html tableData: each ].
 				eachEntity second do: [ :each |
-					html tableData align: 'center';
+					html tableData
+						class: 'wacanvastabletest-aligncenter';
 						with: [ html html: each ] ] ] ] ]

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableBodyOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableBodyOn..st
@@ -3,7 +3,7 @@ renderEntityTableBodyOn: html
 	html tableBody: [
 		self entities do: [ :eachEntity |
 			html tableRow: [
-				html tableData scope: 'row';
+				html tableHeading scope: 'row';
 					with: eachEntity first.
 				eachEntity second do: [ :each |
 					html tableData: each ].

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableColumnGroupsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableColumnGroupsOn..st
@@ -2,4 +2,4 @@ rendering
 renderEntityTableColumnGroupsOn: html
 	html tableColumnGroup.
 	html tableColumnGroup span: 3.
-	html tableColumnGroup span: 3; align: 'center'
+	html tableColumnGroup span: 3; class: 'wacanvastabletest-aligncenter'

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableFootOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/renderEntityTableFootOn..st
@@ -2,5 +2,6 @@ rendering
 renderEntityTableFootOn: html
 	html tableFoot: [
 		html tableRow: [
-			html tableData align: 'center'; colSpan: 7;
+			html tableData colSpan: 7;
+				class: 'wacanvastabletest-aligncenter';
 				with: '5 entities shown' ] ]

--- a/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/style.st
+++ b/repository/Seaside-Tests-Functional.package/WACanvasTableFunctionalTest.class/instance/style.st
@@ -18,4 +18,7 @@ style
 	padding: 3px;
 	border:1px solid black;
 }
+.wacanvastabletest-aligncenter { 
+	text-align: center;
+}
 '

--- a/repository/Seaside-Tests-Functional.package/WAHtml5ElementsTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAHtml5ElementsTest.class/instance/renderContentOn..st
@@ -6,7 +6,6 @@ renderContentOn: html
 	self renderProgressOn: html.
 	self renderTimeOn: html.
 	self renderDetailsOn: html.
-	self renderMenuOn: html.
 	self renderHeadingGroupOn: html.
 	self renderBidirectionalOn: html.
 	self renderBidirectionalOverrideOn: html.

--- a/repository/Seaside-Tests-Functional.package/WAHtml5ElementsTest.class/instance/renderMenuOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAHtml5ElementsTest.class/instance/renderMenuOn..st
@@ -1,8 +1,0 @@
-rendering
-renderMenuOn: html
-	html heading level2; with: '<menu>'.
-
-	html menu: [
-		html command beRadio; label: 'Do 1st Command'.
-		html command beRadio; label: 'Do 2nd Command'.
-		html command beRadio; label: 'Do 3rd Command' ]

--- a/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WALotsaLinksFunctionalTest.class/instance/renderContentOn..st
@@ -5,10 +5,10 @@ renderContentOn: html
 
 	self renderExplanationOn: html.
 	html unorderedList: [
-		(1 to: 5000) do: [ :each | 
+		1 to: 5000 do: [ :each | 
 			html listItem: [
 				html anchor
-					name: each;
+					id: 'linkid-', each greaseString;
 					callback: [
 						self 
 							inform: each

--- a/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderAnchorsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderAnchorsOn..st
@@ -4,7 +4,7 @@ renderAnchorsOn: canvas
 		html unorderedList: [
 			html listItem: [
 					html anchor
-						name: 'name';
+						id: 'name';
 						callback: [ ];
 						with: 'Anchor' ] ] ]
 		factor: 1

--- a/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderInline.factor.key.on..st
+++ b/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderInline.factor.key.on..st
@@ -40,7 +40,9 @@ renderInline: aBlock factor: factor key: key on: html
 	html div
 		class: 'spi';
 		with: [
-			html big: spi greaseString , ' SPI'.
+			html span
+				style: 'font-size: 30px;';
+				with: spi greaseString , ' SPI'.
 			html span
 				class: 'iteration';
 				with: '(' , count greaseString , ' iterations)'.

--- a/repository/Seaside-Tests-Functional.package/WAPhraseElementsFunctionalTest.class/instance/renderAcronymOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAPhraseElementsFunctionalTest.class/instance/renderAcronymOn..st
@@ -1,9 +1,0 @@
-rendering
-renderAcronymOn: html
-
-	html heading level2; with: '<acronym>'.
-
-	html paragraph: [
-		html acronym
-			title: 'Federal Bureau of Investigation';
-			with: 'F.B.I.' ]

--- a/repository/Seaside-Tests-Functional.package/WAPhraseElementsFunctionalTest.class/instance/renderContentOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAPhraseElementsFunctionalTest.class/instance/renderContentOn..st
@@ -2,7 +2,6 @@ rendering
 renderContentOn: html
 	self renderHarryOn: html.
 	self renderAbbreviatedOn: html.
-	self renderAcronymOn: html.
 	self renderKeyboardInputOn: html.
 	self renderVariableOn: html.
 	self renderCodeOn: html.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCanvasTableFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCanvasTableFunctionalTest.st
@@ -28,7 +28,7 @@ testCanvasTableFunctionalTest
     with: entities
     do: [ :row :entityDef | 
       self
-        assert: ((row findElementsByTagName: 'td') collect: #'getText')
+        assert: ((row findElementsByCSSSelector: 'th,td') collect: #'getText')
         equals: entityDef ].
   exchangeRates := #(#('EUR' '1.70') #('USD' '1.30') #('DKK' '23.36') #('SEK' '19.32')).
   currencyTable := (driver findElementsByTagName: 'table')

--- a/repository/Seaside-Widgets.package/WASelectionDateTable.class/instance/renderCellForDate.row.index.on..st
+++ b/repository/Seaside-Widgets.package/WASelectionDateTable.class/instance/renderCellForDate.row.index.on..st
@@ -1,8 +1,7 @@
 rendering
 renderCellForDate: aDate row: anObject index: aNumber on: html
 	html tableData
-		style: 'background-color: ', (self colorForDate: aDate rowIndex: aNumber);
-		align: 'center';
+		style: 'text-align: center; background-color: ', (self colorForDate: aDate rowIndex: aNumber);
 		with: [
 			html anchor
 				callback: [ self selectDate: aDate rowIndex: aNumber ];

--- a/repository/Seaside-Widgets.package/monticello.meta/categories.st
+++ b/repository/Seaside-Widgets.package/monticello.meta/categories.st
@@ -1,3 +1,1 @@
-SystemOrganization addCategory: #'Seaside-Widgets'!
-SystemOrganization addCategory: #'Seaside-Widgets-Components'!
-SystemOrganization addCategory: #'Seaside-Widgets-Decorations'!
+self packageOrganizer ensurePackage: #'Seaside-Widgets' withTags: #(#Components #Decorations)!


### PR DESCRIPTION
Removes the use of tags and attributes currently deprecated (or non-functioning) in HTML5 from the Seaside tests and examples.

Also fix the wrong deprecation of:
- the th.scope attribute (it was only deprecated for td tags).
- the charset attribute on meta tags

Fixes #1418 