### PR TITLE
use title attribute instead of id attribute when rendering anchors as…

### DIFF
--- a/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderAnchorsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WAPerformanceFunctionalTest.class/instance/renderAnchorsOn..st
@@ -4,7 +4,7 @@ renderAnchorsOn: canvas
 		html unorderedList: [
 			html listItem: [
 					html anchor
-						id: 'name';
+						title: 'name';
 						callback: [ ];
 						with: 'Anchor' ] ] ]
 		factor: 1


### PR DESCRIPTION
… the id attribute must be unique on a page (though not an issue in this test, it's better to adhere to correct practices).