### PR TITLE
Improvements for Web Components

### DIFF
--- a/repository/Seaside-Session.package/WASessionContinuation.class/instance/handle..st
+++ b/repository/Seaside-Session.package/WASessionContinuation.class/instance/handle..st
@@ -2,5 +2,5 @@ handling
 handle: aRequestContext
 	"Resume processing of a request. To ensure valid application state restore all registered states."
 
-	self states restore.
+	self restoreState.
 	self withUnregisteredHandlerDo: [ super handle: aRequestContext ]

--- a/repository/Seaside-Session.package/WASessionContinuation.class/instance/restoreState.st
+++ b/repository/Seaside-Session.package/WASessionContinuation.class/instance/restoreState.st
@@ -1,0 +1,4 @@
+processing
+restoreState
+
+	self states restore

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/createCache.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/createCache.st
@@ -1,0 +1,3 @@
+private
+createCache
+	^ WASingleElementCache new

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testClear.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testClear.st
@@ -2,4 +2,4 @@ testing
 testClear
 	cache at: 1 put: 'one'.
 	cache clear.
-	self assert: (cache at: 1 ifAbsent: [ 'two' ]) = 'two'.
+	self assert: (cache at: 1 ifAbsent: [ 'two' ]) equals: 'two'.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testClear.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testClear.st
@@ -1,0 +1,5 @@
+testing
+testClear
+	cache at: 1 put: 'one'.
+	cache clear.
+	self assert: (cache at: 1 ifAbsent: [ 'two' ]) = 'two'.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeyAtValue.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeyAtValue.st
@@ -1,0 +1,5 @@
+testing
+testKeyAtValue
+	cache at: 1 put: 'one'.
+	self assert: (cache keyAtValue: 'one' ifAbsent: [ 2 ]) = 1.
+	self assert: (cache keyAtValue: 'two' ifAbsent: [ 2 ]) = 2.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeyAtValue.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeyAtValue.st
@@ -1,5 +1,5 @@
 testing
 testKeyAtValue
 	cache at: 1 put: 'one'.
-	self assert: (cache keyAtValue: 'one' ifAbsent: [ 2 ]) = 1.
-	self assert: (cache keyAtValue: 'two' ifAbsent: [ 2 ]) = 2.
+	self assert: (cache keyAtValue: 'one' ifAbsent: [ 2 ]) equals: 1.
+	self assert: (cache keyAtValue: 'two' ifAbsent: [ 2 ]) equals: 2.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeysAndValuesDo.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeysAndValuesDo.st
@@ -1,0 +1,13 @@
+testing
+testKeysAndValuesDo
+	| reference readBack |
+	reference := Dictionary new.
+
+	cache at: 1 put: 'one'.
+	reference at: 1 put: 'one'.
+	
+	readBack := Dictionary new.
+	cache keysAndValuesDo: [ :key :value |
+		readBack at: key put: value ].
+	
+	self assert: readBack = reference

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeysAndValuesDo.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testKeysAndValuesDo.st
@@ -10,4 +10,4 @@ testKeysAndValuesDo
 	cache keysAndValuesDo: [ :key :value |
 		readBack at: key put: value ].
 	
-	self assert: readBack = reference
+	self assert: readBack equals: reference

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testSize.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testSize.st
@@ -1,0 +1,7 @@
+testing
+testSize
+	self assert: cache size = 0.
+	cache at: 1 put: 'one'.
+	self assert: cache size = 1.
+	cache at: 2 put: 'two'.
+	self assert: cache size = 1.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testSize.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testSize.st
@@ -1,7 +1,7 @@
 testing
 testSize
-	self assert: cache size = 0.
+	self assert: cache size equals: 0.
 	cache at: 1 put: 'one'.
-	self assert: cache size = 1.
+	self assert: cache size equals: 1.
 	cache at: 2 put: 'two'.
-	self assert: cache size = 1.
+	self assert: cache size equals: 1.

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testStore.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testStore.st
@@ -1,0 +1,10 @@
+testing
+testStore
+	| generator |
+	generator := WAPrecomputedKeyGenerator keys: #(1 2 3).
+	WAKeyGenerator
+		use: generator
+		during: [
+			self assert: (cache store: 'key1') = 1.
+			self assert: (cache store: 'key2') = 2.
+			self assert: (cache store: 'key3') = 3 ]

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testStore.st
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/instance/testStore.st
@@ -5,6 +5,6 @@ testStore
 	WAKeyGenerator
 		use: generator
 		during: [
-			self assert: (cache store: 'key1') = 1.
-			self assert: (cache store: 'key2') = 2.
-			self assert: (cache store: 'key3') = 3 ]
+			self assert: (cache store: 'key1') equals: 1.
+			self assert: (cache store: 'key2') equals: 2.
+			self assert: (cache store: 'key3') equals: 3 ]

--- a/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/properties.json
+++ b/repository/Seaside-Tests-WebComponents.package/WASingleElementCacheTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "WACacheTest",
+	"category" : "Seaside-Tests-WebComponents",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WASingleElementCacheTest",
+	"type" : "normal"
+}

--- a/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/README.md
+++ b/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/README.md
@@ -1,0 +1,1 @@
+I am a session that stores only a single continuation. I am usesful for cases where state snapshots are not used.

--- a/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/instance/createContinuationCache.st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/instance/createContinuationCache.st
@@ -1,0 +1,3 @@
+initialization
+createContinuationCache
+	^ WASingleElementCache new

--- a/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/properties.json
+++ b/repository/Seaside-WebComponents-Core.package/WASingleContinuationSession.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "xxx 7/11/2024 13:25",
+	"super" : "WASession",
+	"category" : "Seaside-WebComponents-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WASingleContinuationSession",
+	"type" : "normal"
+}

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/README.md
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/README.md
@@ -1,0 +1,1 @@
+I am a cache that contains at most one element.

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/at.ifAbsent..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/at.ifAbsent..st
@@ -1,0 +1,5 @@
+accessing
+at: aKey ifAbsent: aBlock
+	^ key = aKey
+		ifTrue: [ value ]
+		ifFalse: [ aBlock value ]

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/at.put..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/at.put..st
@@ -1,0 +1,5 @@
+putting
+at: aKey put: anObject
+	key := aKey.
+	value := anObject.
+	^ anObject

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/clear.st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/clear.st
@@ -1,0 +1,4 @@
+public
+clear
+	key := nil.
+	value := nil

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/keyAtValue.ifAbsent..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/keyAtValue.ifAbsent..st
@@ -1,0 +1,5 @@
+accessing
+keyAtValue: anObject ifAbsent: aBlock
+	^ value = anObject
+		ifTrue: [ key ]
+		ifFalse: [ aBlock value ]

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/keysAndValuesDo..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/keysAndValuesDo..st
@@ -1,0 +1,4 @@
+enumerating
+keysAndValuesDo: aTwoArgumentBlock
+	key isNil ifFalse: [
+		aTwoArgumentBlock value: key value: value ]

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/remove..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/remove..st
@@ -1,0 +1,5 @@
+removing
+remove: anObject
+	value = anObject ifTrue: [
+		key := nil.
+		value := nil ]

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/size.st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/size.st
@@ -1,0 +1,5 @@
+accessing
+size
+	^ key isNil
+		ifTrue: [ 0 ]
+		ifFalse: [ 1 ]

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/store..st
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/instance/store..st
@@ -1,0 +1,5 @@
+putting
+store: anObject
+	key := WAKeyGenerator current keyOfLength: self keySize.
+	value := anObject.
+	^ key

--- a/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/properties.json
+++ b/repository/Seaside-WebComponents-Core.package/WASingleElementCache.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"commentStamp" : "xxx 7/11/2024 10:46",
+	"super" : "WACache",
+	"category" : "Seaside-WebComponents-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"key",
+		"value"
+	],
+	"name" : "WASingleElementCache",
+	"type" : "normal"
+}

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/README.md
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/README.md
@@ -1,0 +1,7 @@
+I am a special action continuation with optimizations for web components.
+
+Since web components have no back button and a full page reload results in an entire new page I perform the following optimizations.
+
+- I do not redirect.
+- I do not capture the state.
+- I do not restore the state.

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/basicPerformAction.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/basicPerformAction.st
@@ -1,0 +1,4 @@
+processing
+basicPerformAction
+	super basicPerformAction.
+	self renderContext callbacks handle: self requestContext

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/continue.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/continue.st
@@ -1,0 +1,4 @@
+processing
+continue
+	"do not capture state"
+	self createRenderContinuation handle: self requestContext

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/handle..st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/handle..st
@@ -1,4 +1,0 @@
-handling
-handle: aRequestContext
-	"don't restore states"
-	self withUnregisteredHandlerDo: [ super handle: aRequestContext ]

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/handle..st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/handle..st
@@ -1,0 +1,4 @@
+handling
+handle: aRequestContext
+	"don't restore states"
+	self withUnregisteredHandlerDo: [ super handle: aRequestContext ]

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/jumpToAnchor..st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/jumpToAnchor..st
@@ -1,0 +1,3 @@
+public
+jumpToAnchor: aString
+	"Intentionally empty for compatibility with WACallbackProcessingActionContinuation"

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/restoreState.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/restoreState.st
@@ -1,0 +1,3 @@
+processing
+restoreState
+	"don't restore states"

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/shouldRedirect.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/instance/shouldRedirect.st
@@ -1,0 +1,3 @@
+private
+shouldRedirect
+	^ false

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/properties.json
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentActionContinuation.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "xxx 7/11/2024 13:24",
+	"super" : "WAActionPhaseContinuation",
+	"category" : "Seaside-WebComponents-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WAWebComponentActionContinuation",
+	"type" : "normal"
+}

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/instance/seasideWebComponentsJs.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/instance/seasideWebComponentsJs.st
@@ -37,7 +37,7 @@ seasideWebComponentsJs
     #load(method, url, data) {
       const xhr = new XMLHttpRequest();
 
-      xhr.responseType = "text";  // we do not stirp anyhing, just use innerHtml
+      xhr.responseType = "text";  // we do not strip anyhing, just use innerHtml
       xhr.addEventListener("load", (event) => {
         if (xhr.status === 200) {
           this.#shadowRoot.innerHTML = xhr.response;

--- a/repository/Seaside-WebComponents-Examples.package/WAHeadlessCounter.class/class/initialize.st
+++ b/repository/Seaside-WebComponents-Examples.package/WAHeadlessCounter.class/class/initialize.st
@@ -4,5 +4,8 @@ initialize
 	"register such that we do not have the developer tools"
 	application := WAAdmin register: WAApplication at: 'examples/headless-counter' in: WAAdmin defaultDispatcher.
 	application configuration addParent: WARenderLoopConfiguration instance.
-	application rootClass: self.
-	application preferenceAt: #renderPhaseContinuationClass put: WAFragmentRenderPhaseContinuation
+	application
+		rootClass: self;
+		sessionClass: WASingleContinuationSession;
+		preferenceAt: #renderPhaseContinuationClass put: WAFragmentRenderPhaseContinuation;
+		preferenceAt: #actionPhaseContinuationClass put: WAWebComponentActionContinuation

--- a/repository/Seaside-WebComponents-Examples.package/WAWebComponentsDemoApplication.class/class/initialize.st
+++ b/repository/Seaside-WebComponents-Examples.package/WAWebComponentsDemoApplication.class/class/initialize.st
@@ -1,4 +1,9 @@
 initialization
 initialize
-	(WAAdmin register: self asApplicationAt: 'examples/web-components')
+	| application |
+	"register such that we do not have the developer tools"
+	application := WAAdmin register: WAApplication at: 'examples/web-components' in: WAAdmin defaultDispatcher.
+	application configuration addParent: WARenderLoopConfiguration instance.
+	application
+		rootClass: self;
 		scriptGeneratorClass: WANullScriptGenerator


### PR DESCRIPTION
Improvements that allow applications with Web Components to run with a lower overhead.

- Save only a single action continuation. Since the back button does not work with Web Components in general we only need to save a single action continuation. This should keep sessions smaller.
- Dedicated action continuation. Since the back button does not work with Web Components in general we can make use of an optimized action continuation that:
  - does not redirect.
  - does not capture state.
  - does not restore state.

In theory these classes could be used in general for "back button less" Seaside applications. However this is quite an advanced topic so I think it's ok to "burry" these in the WebComponents package. Let me know what you think.