### PR TITLE
Workaround for chomedriver/selenium issue in functional tests

### DIFF
--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
@@ -6,37 +6,25 @@ testCallbackFunctionalTest
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'Default').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Text: Some Text'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before Submit' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'Before Submit').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before Cancel' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Before Cancel'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Text: Some Text'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After Submit' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'After Submit').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After Cancel' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'After Cancel'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
@@ -3,6 +3,7 @@ testCallbackFunctionalTest
 	self selectTest: 'WACallbackFunctionalTest'.
 	
 	(driver findElementByCSSSelector: 'input[type=text]') sendKey: BPKeys enter.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'Default').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before' ]) click.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCallbackFunctionalTest.st
@@ -6,19 +6,37 @@ testCallbackFunctionalTest
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'Default').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Text: Some Text'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before Submit' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'Before Submit').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'Before Cancel' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Before Cancel'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'Text: Some Text'.
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After Submit' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: ('Text: Some Text', Character lf greaseString,'After Submit').
 	
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :button | (button getAttribute: 'value') = 'After Cancel' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'pre') getText equals: 'After Cancel'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCookieFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCookieFunctionalTest.st
@@ -8,9 +8,7 @@ testCookieFunctionalTest
 	(firstRow findElementsByTagName: 'input') first sendKeys: 'seaside'.
 	(firstRow findElementsByTagName: 'input') second sendKeys: 'aubergine'.
 	(driver findElementByID: #addFirstCookie) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'seaside') & (row getText includesSubstring: 'aubergine') ]).
 	
@@ -21,15 +19,11 @@ testCookieFunctionalTest
 	(secondRow findElementsByTagName: 'input') first sendKeys: 'parasol'.
 	(secondRow findElementsByTagName: 'input') second sendKeys: 'sunscreen'.
 	(driver findElementByID: #addSecondCookie) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'parasol') & (row getText includesSubstring: 'sunscreen') ]).
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]).
 	
 	(((driver findElementsByTagName: 'tr') detect:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]) findElementByCSSSelector: 'input[type=submit]') click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self deny: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]).

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCookieFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCookieFunctionalTest.st
@@ -8,6 +8,9 @@ testCookieFunctionalTest
 	(firstRow findElementsByTagName: 'input') first sendKeys: 'seaside'.
 	(firstRow findElementsByTagName: 'input') second sendKeys: 'aubergine'.
 	(driver findElementByID: #addFirstCookie) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'seaside') & (row getText includesSubstring: 'aubergine') ]).
 	
@@ -18,9 +21,15 @@ testCookieFunctionalTest
 	(secondRow findElementsByTagName: 'input') first sendKeys: 'parasol'.
 	(secondRow findElementsByTagName: 'input') second sendKeys: 'sunscreen'.
 	(driver findElementByID: #addSecondCookie) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'parasol') & (row getText includesSubstring: 'sunscreen') ]).
 	self assert: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]).
 	
 	(((driver findElementsByTagName: 'tr') detect:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]) findElementByCSSSelector: 'input[type=submit]') click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self deny: ((driver findElementsByTagName: 'tr') anySatisfy:[ :row | (row getText includesSubstring: 'grease') & (row getText includesSubstring: 'monkey') ]).

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateSelectorFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateSelectorFunctionalTest.st
@@ -18,8 +18,10 @@ testDateSelectorFunctionalTest
 	(BPSelect on: (toDateSelects at: 3)) selectByVisibleText: toDate year greaseString.
 
 	(((driver findElementByID: #dateForm) findElementByXPath: './ancestor-or-self::form') findElementByCSSSelector: 'input[type=submit]') click.
+	self workaroundChromeDriver.
 	self assert: ((driver findElementByTagName:'h3') getText includesSubstring: '300 day(s)').
 	(driver findElementByCSSSelector: 'input[type=submit]') click.
+	self workaroundChromeDriver.
 	
 	fromTime := Time hour: 16 minute: 30 second: 10.
 	deltaTime := Time hour: 4 minute: 30 second: 10.
@@ -36,8 +38,10 @@ testDateSelectorFunctionalTest
 	(BPSelect on: (toTimeSelects at: 3)) selectByVisibleText: toTime seconds greaseString.
 	
 	(((driver findElementByID: #timeForm) findElementByXPath: './ancestor-or-self::form') findElementByCSSSelector: 'input[type=submit]') click.
+	self workaroundChromeDriver.
 	self assert: ((driver findElementByTagName:'h3') getText includesSubstring: deltaTime asSeconds greaseString,' second(s)').
 	(driver findElementByCSSSelector: 'input[type=submit]') click.
+	self workaroundChromeDriver.
 	
 	fromDateAndTime := DateAndTime now.
 	deltaDuration := Duration days: 10 hours: 4 minutes: 30 seconds: 10.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateTimeFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateTimeFunctionalTest.st
@@ -30,8 +30,6 @@ testDateTimeFunctionalTest
 		sendKey: (BPKeys backSpace);
 		sendKeys: dateTime asTime seconds greaseString.
 	((driver findElementByID: #inputs) findElementByCSSSelector: 'input[type=submit]') click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 
 	self assert: ((driver findElementByID: #inputs) getText includesSubstring: 'Button action: ' , dateTime asDate greaseString , ' ' , dateTime asTime greaseString)

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateTimeFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDateTimeFunctionalTest.st
@@ -30,5 +30,8 @@ testDateTimeFunctionalTest
 		sendKey: (BPKeys backSpace);
 		sendKeys: dateTime asTime seconds greaseString.
 	((driver findElementByID: #inputs) findElementByCSSSelector: 'input[type=submit]') click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 
 	self assert: ((driver findElementByID: #inputs) getText includesSubstring: 'Button action: ' , dateTime asDate greaseString , ' ' , dateTime asTime greaseString)

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
@@ -7,7 +7,8 @@ testDelegationFunctionalTest
   step2VisiblePresenters := OrderedCollection new.
   step1cVisiblePresenters := OrderedCollection new.	"1"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
-	self workaroundChromeDriver.
+  (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+  self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1aVisiblePresenters add: presenter class name ].

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
@@ -8,6 +8,9 @@ testDelegationFunctionalTest
   step1cVisiblePresenters := OrderedCollection new.	"1"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1aVisiblePresenters add: presenter class name ].
@@ -26,6 +29,9 @@ testDelegationFunctionalTest
   self assert: step1aVisiblePresenters equals: step1bVisiblePresenters.	"3"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step2VisiblePresenters add: presenter class name ].

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testDelegationFunctionalTest.st
@@ -7,10 +7,7 @@ testDelegationFunctionalTest
   step2VisiblePresenters := OrderedCollection new.
   step1cVisiblePresenters := OrderedCollection new.	"1"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
-  (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1aVisiblePresenters add: presenter class name ].
@@ -29,9 +26,7 @@ testDelegationFunctionalTest
   self assert: step1aVisiblePresenters equals: step1bVisiblePresenters.	"3"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step2VisiblePresenters add: presenter class name ].

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testEncodingFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testEncodingFunctionalTest.st
@@ -14,5 +14,8 @@ testEncodingFunctionalTest
 					headingid := idpart , 'heading'.
 					((driver findElementByID: formid) findElementByCSSSelector: 'input[type=text]') sendKeys: sentence.
 					((driver findElementByID: formid) findElementByCSSSelector: 'input[type=submit]') click.
+							"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+							"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+							(Delay forMilliseconds: 500) wait.
 					self assert: (driver findElementByID: headingid) getText equals: idpart , sentence ]
 				separatedBy: [ ((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Restart' ]) click ] ]

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testEncodingFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testEncodingFunctionalTest.st
@@ -14,8 +14,6 @@ testEncodingFunctionalTest
 					headingid := idpart , 'heading'.
 					((driver findElementByID: formid) findElementByCSSSelector: 'input[type=text]') sendKeys: sentence.
 					((driver findElementByID: formid) findElementByCSSSelector: 'input[type=submit]') click.
-							"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-							"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-							(Delay forMilliseconds: 500) wait.
+					self workaroundChromeDriver.
 					self assert: (driver findElementByID: headingid) getText equals: idpart , sentence ]
 				separatedBy: [ ((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Restart' ]) click ] ]

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
@@ -36,5 +36,6 @@ testExceptionFunctionalTest
 
 	self scrollWindowBy: 10@800 "need to scroll into view, especially when running headful".
 	(driver findElementByLinkText: 'Raise deprecated') click.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'To be displayed'.
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect: [ :i | (i getAttribute: 'value') = 'Ok' ]) click.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
@@ -12,10 +12,14 @@ testExceptionFunctionalTest
 	driver goBack.
 	
 	((driver findElementsByCSSSelector: 'button[type=submit]') detect: [ :i | i getText = 'Raise error in POST' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h1') getText equals: 'WAError: Test Error'.
 	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
 	driver goBack.
-	
+
+	self scrollWindowBy: 10@800 "need to scroll into view, especially when running headful".	
 	(driver findElementByLinkText: 'Raise error during rendering') click.
 	self assert: ((driver findElementsByTagName: 'h1') anySatisfy: [ :e | e getText = 'WAError: Error during rendering.' ]).
 	self assert: ((driver findElementsByTagName: 'p') anySatisfy: [ :e | e getText = 'Your request could not be completed. An exception occurred.' ]).

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testExceptionFunctionalTest.st
@@ -12,9 +12,7 @@ testExceptionFunctionalTest
 	driver goBack.
 	
 	((driver findElementsByCSSSelector: 'button[type=submit]') detect: [ :i | i getText = 'Raise error in POST' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h1') getText equals: 'WAError: Test Error'.
 	self assert: (driver findElementByTagName: 'p') getText equals: 'Your request could not be completed. An exception occurred.'.
 	driver goBack.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest.st
@@ -6,9 +6,7 @@ testFlowClosureFunctionalTest
 	
 	doClickButton := [ (
 		(driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait ].
+		self workaroundChromeDriver. ].
 	
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest.st
@@ -1,20 +1,24 @@
 testing
 testFlowClosureFunctionalTest
 
-	| okButton |
+	| doClickButton |
 	self selectTest: 'WAFlowClosureFunctionalTest'.
 	
-	okButton := [ (driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ] ].
+	doClickButton := [ (
+		(driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait ].
 	
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '2'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '2'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '3'.
-	okButton value click.
+	doClickButton value.
 	self shouldnt: [ (driver findElementByPartialLinkText: 'Go') ] raise: BPNotFoundException

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest2.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest2.st
@@ -1,30 +1,34 @@
 testing
 testFlowClosureFunctionalTest2
 
-	| okButton |
+	| doClickButton |
 	self selectTest: 'WAFlowClosureFunctionalTest'.
 	"Some weird behavior goes on when returning to the start of the functional test. Error in Seaside or... ??"
-	okButton := [ (driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ] ].
+	doClickButton := [ 
+		((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ]) click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait ].
 	
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '2'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
 	driver goBack.
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '2'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
 	driver goBack.	
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '2'.
-	okButton value click.
+	doClickButton value.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '3'.
-	okButton value click.
+	doClickButton value.
 	self shouldnt: [ (driver findElementByPartialLinkText: 'Go') ] raise: BPNotFoundException

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest2.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowClosureFunctionalTest2.st
@@ -6,9 +6,7 @@ testFlowClosureFunctionalTest2
 	"Some weird behavior goes on when returning to the start of the functional test. Error in Seaside or... ??"
 	doClickButton := [ 
 		((driver findElementsByCSSSelector: 'input[type=submit]') detect:[ :e | (e getAttribute: 'value') = 'Ok' ]) click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait ].
+		self workaroundChromeDriver. ].
 	
 	(driver findElementByPartialLinkText: 'Go') click.
 	self assert: (driver findElementByTagName: 'h3') getText equals: '1'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowConvenienceFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowConvenienceFunctionalTest.st
@@ -12,66 +12,44 @@ testFlowConvenienceFunctionalTest
 	
 	selectOption value: 'Greyerzer'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Greyerzer your favorite cheese?'.
 	yesButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Greyerzer.'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	
 	selectOption value: 'Tilsiter'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	selectOption value: 'Tilsiter'.
 	cancelButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	selectOption value: 'Tilsiter'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	yesButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Tilsiter.'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	noButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	
 	selectOption value: 'Sbrinz'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Sbrinz your favorite cheese?'.
 	yesButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Sbrinz.'.
 	okButton value click.
-		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
-		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
-		(Delay forMilliseconds: 500) wait.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowConvenienceFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowConvenienceFunctionalTest.st
@@ -12,33 +12,66 @@ testFlowConvenienceFunctionalTest
 	
 	selectOption value: 'Greyerzer'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Greyerzer your favorite cheese?'.
 	yesButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Greyerzer.'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	
 	selectOption value: 'Tilsiter'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	selectOption value: 'Tilsiter'.
 	cancelButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	selectOption value: 'Tilsiter'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	yesButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Tilsiter.'.
 	driver goBack.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Tilsiter your favorite cheese?'.
 	noButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'.
 	
 	selectOption value: 'Sbrinz'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Is Sbrinz your favorite cheese?'.
 	yesButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'Your favorite cheese is Sbrinz.'.
 	okButton value click.
+		"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)"
+		"Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+		(Delay forMilliseconds: 500) wait.
 	self assert: (driver findElementByTagName: 'h3') getText equals: 'What''s your favorite Cheese?'

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowDelegationFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowDelegationFunctionalTest.st
@@ -8,6 +8,7 @@ testFlowDelegationFunctionalTest
   step1cVisiblePresenters := OrderedCollection new.	"1"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+  self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1aVisiblePresenters add: presenter class name ].
@@ -20,22 +21,22 @@ testFlowDelegationFunctionalTest
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1bVisiblePresenters add: presenter class name ].
   self
-    assert:
-      (step1bVisiblePresenters select: [ :p | p = #'WAAnswerHandler' ]) size
+    assert: (step1bVisiblePresenters select: [ :p | p = #'WAAnswerHandler' ]) size
     equals: 1.
   self assert: step1aVisiblePresenters equals: step1bVisiblePresenters.	"3"
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+  self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 2'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step2VisiblePresenters add: presenter class name ].
   self assert: step1aVisiblePresenters equals: step2VisiblePresenters.	"4"
   (driver findElementByCSSSelector: 'input[type=submit][value=Ok]') click.
+  self workaroundChromeDriver.
   self assert: (driver findElementByTagName: 'h3') getText equals: 'Step 1'.
   self componentUnderTest
     visiblePresentersDo: [ :presenter | step1cVisiblePresenters add: presenter class name ].
   self
-    assert:
-      (step1cVisiblePresenters select: [ :p | p = #'WAAnswerHandler' ]) size
+    assert: (step1cVisiblePresenters select: [ :p | p = #'WAAnswerHandler' ]) size
     equals: 1.
   self assert: step1aVisiblePresenters equals: step1cVisiblePresenters

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowErrorFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowErrorFunctionalTest.st
@@ -5,7 +5,9 @@ testFlowErrorFunctionalTest
 
 	(BPSelect on: (driver findElementByID: 'handlerselect')) selectByVisibleText: 'WAHtmlErrorHandler'.
 	(driver findElementByID: #sethandler) click.
+	self workaroundChromeDriver.
 	(driver findElementByLinkText: 'Raise error') click.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h1') getText = 'WAError: Test Error'.
 	self assert: (driver findElementByTagName: 'p') getText = 'Your request could not be completed. An exception occurred.'.
 	driver goBack.
@@ -13,6 +15,6 @@ testFlowErrorFunctionalTest
 	(driver findElementByLinkText: 'Raise error in called component') click.
 	self assert: (driver findElementByTagName: 'h3') getText = 'Once you close this, an error will be raised.'.
 	((driver findElementsByCSSSelector: 'input[type=submit]') detect: [ :i | (i getAttribute: 'value') = 'Ok' ]) click.
-	
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'h1') getText = 'WAError: Test Error'.
 	self assert: (driver findElementByTagName: 'p') getText = 'Your request could not be completed. An exception occurred.'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowFunctionalTest.st
@@ -19,4 +19,5 @@ testFlowFunctionalTest
     (GRPlatform current class == (Smalltalk at: #GRGemStonePlatform ifAbsent:[ nil ]) and: [ i > 1 ])
       ifTrue: [ stackdepth := ' ' , (stackdepth asInteger + 1) greaseString ].
     ((driver findElementsByCSSSelector: 'input[type=submit]')
-      detect: [ :e | (e getAttribute: 'value') = 'Ok' ]) click ]
+      detect: [ :e | (e getAttribute: 'value') = 'Ok' ]) click.
+	self workaroundChromeDriver ]

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testFlowFunctionalTest.st
@@ -3,16 +3,14 @@ testFlowFunctionalTest
   | stackdepth |
   self selectTest: 'WAFlowFunctionalTest'.
   (driver findElementByPartialLinkText: 'go anchors') click.
-  stackdepth := (driver findElementByPartialLinkText: '1:') getText
-    copyAfterLast: $:.
+  stackdepth := (driver findElementByPartialLinkText: '1:') getText copyAfterLast: $:.
   1 to: 5 do: [ :i | 
-    self
-      assert:
-        ((driver findElementByPartialLinkText: i greaseString , ':') getText
-          copyAfterLast: $:)
+    self 
+		assert: ((driver findElementByPartialLinkText: i greaseString , ':') getText copyAfterLast: $:)
       equals: stackdepth.
     (driver findElementByPartialLinkText: i greaseString , ':') click ].
   (driver findElementByPartialLinkText: 'go buttons') click.
+  self workaroundChromeDriver.
   stackdepth := (driver findElementByTagName: 'h3') getText copyAfterLast: $:.
   1 to: 5 do: [ :i | 
     self

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testParameterFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testParameterFunctionalTest.st
@@ -4,4 +4,5 @@ testParameterFunctionalTest
 	self selectTest: 'WAParameterFunctionalTest'.
 	
 	((driver findElementsByCSSSelector: 'input[type="submit"]') detect: [ :e | (e getAttribute:'value') = 'run test' ]) click.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'strong') getText equals: 'success'

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testTaskErrorFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testTaskErrorFunctionalTest.st
@@ -8,13 +8,16 @@ testTaskErrorFunctionalTest
 	self assert: resultText equals: 'Raise an exception?'.
 			
 	((driver findElementByClassName: 'dialog-button-yes') findElementByTagName: 'input') click.
+	self workaroundChromeDriver.
 	resultText := (driver findElementByTagName: 'h3') getText.
 	self assert: ('Caught:*foo' match: resultText).
 	
 	((driver findElementByClassName: 'dialog-button-ok') findElementByTagName: 'input') click.
+	self workaroundChromeDriver.
 	resultText := (driver findElementByTagName: 'h3') getText.
 	self assert: resultText equals: 'Raise an exception?'.
 	
 	((driver findElementByClassName: 'dialog-button-no') findElementByTagName: 'input') click.
+	self workaroundChromeDriver.
 	resultText := (driver findElementByTagName: 'h3') getText.
 	self assert: resultText equals: 'Raise an exception?'.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUploadFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUploadFunctionalTest.st
@@ -13,6 +13,6 @@ testUploadFunctionalTest
 
 		(driver findElementByCSSSelector: 'input[type=file]') sendKeys: filePathString.
 		(driver findElementByCSSSelector: 'input[value=Load]') click.
-
+		self workaroundChromeDriver.
 		self assert: (driver findElementByCSSSelector: 'pre') getText equals: 'blabla'
 	] ensure: [ GRPlatform current deleteFile: filePathString ]

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUrlEncodingFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUrlEncodingFunctionalTest.st
@@ -6,6 +6,7 @@ testUrlEncodingFunctionalTest
 	checkAction := [ :text | 
 		(driver findElementByID: 'input') clear; sendKeys: text.
 		((driver findElementByID: 'input') findElementByXPath: '../input[@type="submit"]') click.
+		self workaroundChromeDriver.
 		self assert: (driver findElementByID: 'inputresult') getText equals: text.
 		self assert: (driver findElementByID: 'parameterresult') getText equals: text.
 		self assert: (driver findElementByID: 'pathresult') getText equals: text ].

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
@@ -1,6 +1,9 @@
 as yet unclassified
 workaroundChromeDriver
 	"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)
-	Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+	Discussion:
+		- https://issues.chromium.org/issues/402796660
+		- https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw
+		- https://github.com/teamcapybara/capybara/issues/2800"
 
 	(Delay forMilliseconds: 500) wait

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
@@ -1,4 +1,4 @@
-as yet unclassified
+helpers
 workaroundChromeDriver
 	"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)
 	Discussion:

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverTestCase.class/instance/workaroundChromeDriver.st
@@ -1,0 +1,6 @@
+as yet unclassified
+workaroundChromeDriver
+	"Webdriver suddenly stopped waiting for the page to navigate after submitting (March 2025)
+	Discussion: https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw"
+
+	(Delay forMilliseconds: 500) wait


### PR DESCRIPTION
Chromedriver/Selenium suddenly stopped waiting for the page to navigate after submitting in v134 of Chrome. Since it's not being fixed, I introduced a 'wait' workaround in our tests.
Discussions:
- https://issues.chromium.org/issues/402796660
- https://groups.google.com/g/selenium-users/c/vfG6A6XVkA0/m/F351RKv5BAAJw
- https://github.com/teamcapybara/capybara/issues/2800