### PR TITLE
Add exception handling for Web Components

### DIFF
--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/README.md
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/README.md
@@ -33,3 +33,17 @@ You can opt in to ajaxification using
 ```language=HTML
 <seaside-component url="/examples/headless-counter" ajaxify="true">Loading...</seaside-component>
 ```
+
+# Error Handling
+
+If Ajax calls fails the library generates events of type "wa-component.xhr" to which the embedding page can listen. For example with code similar to this
+
+```language=JavaScript
+const components = document.getElementsByTagName("wa-component");
+for (const component of components) {
+	component.addEventListener("wa-component.xhr", (event) => {
+		console.error("wa-component xhr call failed %O", event) });
+};
+```
+
+The event handler has to be registered before the first AJAX call is made (the component is connected).

--- a/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/instance/seasideWebComponentsJs.st
+++ b/repository/Seaside-WebComponents-Core.package/WAWebComponentsLibrary.class/instance/seasideWebComponentsJs.st
@@ -3,6 +3,7 @@ seasideWebComponentsJs
 	^ '"use strict";
 (function() {
   class WaComponent extends HTMLElement {
+    static ELEMENT_NAME = "wa-component";
     #shadowRoot;
     constructor() {
       super();
@@ -34,15 +35,32 @@ seasideWebComponentsJs
       });
     }
 
+    #publishXhrEvent(type, cause) {
+      this.#shadowRoot.dispatchEvent(new CustomEvent(WaComponent.ELEMENT_NAME + ".xhr", {
+          bubbles: true,
+          cancelable: false,
+          composed: true,
+          detail: {
+            type: type,
+            cause: cause
+          },
+       }));
+    }
+
     #load(method, url, data) {
       const xhr = new XMLHttpRequest();
 
       xhr.responseType = "text";  // we do not strip anyhing, just use innerHtml
-      xhr.addEventListener("load", (event) => {
-        if (xhr.status === 200) {
+      xhr.onload = (event) => {
+        const status = xhr.status;
+        if (status === 200) {
           this.#shadowRoot.innerHTML = xhr.response;
+        } else if (status >= 400 && status <= 599) {
+          this.#publishXhrEvent("status", event);
         }
-      });
+      };
+      xhr.onerror = (event) => { this.#publishXhrEvent("error", event); };
+      xhr.ontimeout = (event) => { this.#publishXhrEvent("timeout", event); };
 		
       xhr.open(method, url);
 
@@ -62,6 +80,6 @@ seasideWebComponentsJs
     }
   }
 
-  customElements.define("wa-component", WaComponent);
+  customElements.define(WaComponent.ELEMENT_NAME, WaComponent);
 })();
 '

--- a/repository/Seaside-WebComponents-Examples.package/WAWebComponentsDemoApplication.class/instance/renderContentOn..st
+++ b/repository/Seaside-WebComponents-Examples.package/WAWebComponentsDemoApplication.class/instance/renderContentOn..st
@@ -4,4 +4,11 @@ renderContentOn: html
 	(html tag: 'wa-component')
 		attributeAt: 'url' put: '/examples/headless-counter';
 		attributeAt: 'ajaxify' put: 'true';
-		with: 'Loading...'
+		with: 'Loading...'.
+	html script: '
+		const components = document.getElementsByTagName("wa-component");
+		for (const component of components) {
+			component.addEventListener("wa-component.xhr", (event) => {
+				console.error("wa-component xhr call failed %O", event) });
+		};'
+	


### PR DESCRIPTION
`seasideWebComponents.js` now generates events of type `wa-component.xhr` in case XHR events fail. The embedding page can listen to these and act accordingly. `WAWebComponentsDemoApplication` has been updated with code that handles these events.