### PR TITLE
Camp 2025 Squeak fixes round 1

### DIFF
--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/hasZinc.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/hasZinc.st
@@ -1,0 +1,4 @@
+private
+hasZinc
+
+	^ Smalltalk includesKey: #ZnServer

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUploadFunctionalTestWithStreamingUploads.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testUploadFunctionalTestWithStreamingUploads.st
@@ -1,7 +1,10 @@
 testing
 testUploadFunctionalTestWithStreamingUploads
-
 	| originalStreamUploadsSetting |
+	
+	"skip if Zinc not present, for example on Squeak"
+	self hasZinc ifFalse: [ ^ self ].
+	
 	originalStreamUploadsSetting := self zincServer streamUploads.
 	[ 
 		self zincServer streamUploads: true.

--- a/repository/Seaside-Tests-Pharo-Development.package/WAPharoDebuggerTest.class/instance/testNamedTempAt.st
+++ b/repository/Seaside-Tests-Pharo-Development.package/WAPharoDebuggerTest.class/instance/testNamedTempAt.st
@@ -16,6 +16,10 @@ testNamedTempAt
 		| tempNames |
 		"fails on Squeak"
 		self shouldnt: [ tempNames := each tempNames ] raise: Notification.
-		tempNames do: [ :name |
-			"fails on Pharo"
-			self shouldnt: [ each tempNamed: name ] raise: Error ] ]
+		tempNames withIndexDo: [ :name :index  |
+			(each respondsTo: #tempNamed:)
+				ifTrue: [
+					"fails on Pharo"
+					self shouldnt: [ each tempNamed: name ] raise: Error ]
+				ifFalse: [
+					self shouldnt: [ each namedTempAt: index ] raise: Error ] ] ]


### PR DESCRIPTION
- Skip Zinc streaming tests if Zinc is not loaded
- Use Squeak context API