### PR TITLE
Writing JSON dictionaries with non-string keys is now defaulted to produce an error

### DIFF
--- a/repository/Seaside-JSON-Core.package/Object.extension/instance/jsonKeyOn..st
+++ b/repository/Seaside-JSON-Core.package/Object.extension/instance/jsonKeyOn..st
@@ -1,4 +1,4 @@
 *Seaside-JSON-Core
 jsonKeyOn: aRenderer
 
-	self error: 'Only Strings can be used as keys in JSON objects.'
+	WAJsonSyntaxError signal: 'Only Strings can be used as keys in JSON objects.'

--- a/repository/Seaside-JSON-Core.package/WAJsonKeyValueBrush.class/class/stringKeysOnly.st
+++ b/repository/Seaside-JSON-Core.package/WAJsonKeyValueBrush.class/class/stringKeysOnly.st
@@ -1,3 +1,3 @@
 accessing
 stringKeysOnly
-	^ StringKeysOnly ifNil: [ false ]
+	^ StringKeysOnly ifNil: [ true ]

--- a/repository/Seaside-Tests-JSON.package/WAJsonRenderingTest.class/instance/testObject.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonRenderingTest.class/instance/testObject.st
@@ -13,7 +13,6 @@ testObject
 				json key: '1' value: 1 ] ]
 		gives: '{"1": 1}'.
 
-	WAJsonKeyValueBrush stringKeysOnly: true.
 	self
 		should: [
 				self
@@ -21,7 +20,13 @@ testObject
 						json object: [
 							json key: 1 value: 1 ] ]
 					gives: '{"1": 1}' ]
-		raise: Error
-		withExceptionDo: [ :e | self assert: e messageText equals: 'Only Strings can be used as keys in JSON objects.' ].
+		raise: WAJsonSyntaxError.
 
-	
+	[ 
+		WAJsonKeyValueBrush stringKeysOnly: false.
+		self
+			assert: [ :json |
+				json object: [
+					json key: 1 value: 1 ] ]
+			gives: '{1: 1}' 
+	] ensure: [  WAJsonKeyValueBrush stringKeysOnly: true ]

--- a/repository/Seaside-Tests-JSON.package/WAJsonStreamTest.class/instance/testDictionaryWithNonStringKeys.st
+++ b/repository/Seaside-Tests-JSON.package/WAJsonStreamTest.class/instance/testDictionaryWithNonStringKeys.st
@@ -1,20 +1,16 @@
 tests
 testDictionaryWithNonStringKeys
-
-	WAJsonKeyValueBrush stringKeysOnly: true.
 	
 	self
 		should: [
 			(Dictionary new
 				 at: #( 1 2 ) put: 'awkward';
 				 yourself) asJson ]
-		raise: Error
-		withExceptionDo: [ :e | self assert: e messageText equals: 'Only Strings can be used as keys in JSON objects.' ].
+		raise: WAJsonSyntaxError.
 		
 	self
 		should: [
 			((Dictionary new)
 				at: 1 put: 'not-a-string';
 				yourself) asJson ]
-		raise: Error
-		withExceptionDo: [ :e | self assert: e messageText equals: 'Only Strings can be used as keys in JSON objects.' ].
+		raise: WAJsonSyntaxError


### PR DESCRIPTION
Now an WAJsonSyntaxError is thrown when writing a JSON dictionary on the WAJsonCanvas with a key that is not a string. This is invalid JSON and was possible before.

Fixes https://github.com/SeasideSt/Seaside/issues/1474 and https://github.com/SeasideSt/Seaside/issues/1475