### PR TITLE
1484: Ensure Seaside-HotwireTurbo-Examples only loads in Pharo.

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -23,7 +23,7 @@ SmalltalkCISpec {
       #directory : 'repository',
       #onWarningLog : true,
       #onConflict : #useIncoming,
-      #load : [ 'CI' ],
+      #load : [ 'CI' , 'Examples' ],
       #platforms : [ #gemstone ]
     }
   ],

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinecommon..st
@@ -118,4 +118,4 @@ baselinecommon: spec
 			group: 'Development' with: #('Core' 'Seaside-Development');
 			group: 'Development Tests' with: #('Development' 'Core' 'Seaside-Tests-Development');
 			group: 'Email' with: #('Seaside-Email');
-			group: 'Examples' with: #('Core' 'Seaside-Examples' 'Seaside-REST-Examples' 'Seaside-HotwireTurbo-Examples' 'Seaside-WebComponents-Examples') ].
+			group: 'Examples' with: #('Core' 'Seaside-Examples' 'Seaside-REST-Examples' 'Seaside-WebComponents-Examples') ].

--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinepharo..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinepharo..st
@@ -58,4 +58,5 @@ baselinepharo: spec
 				package: 'Seaside-Pharo100-Tools-Spec2' with: [ spec requires: #('Seaside-Tools-Core') ].
 				
 			spec
-				group: 'Tests' with: #('Seaside-Tests-Microdown') ]
+				group: 'Tests' with: #('Seaside-Tests-Microdown');
+				group: 'Examples' with: #('Seaside-HotwireTurbo-Examples') ]


### PR DESCRIPTION
This PR moves the Seaside-HotwireTurbo-Examples package to baselinepharo: to avoid it loading outside of Pharo.

GemStone internal testing loads the 'Examples' group during testing. Loading it revealed this problem. I added it to the CI runner. Are you ok with loading Examples during GemStone testing @jbrichau?