### PR TITLE
Extend CORS Filter with all possible response headers + allow only a single value in Allow-Origin header

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinerest..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselinerest..st
@@ -48,7 +48,7 @@ baselinerest: spec
 	].
 
 	spec 
-		for: #('pharo9.x' 'pharo10.x' 'pharo11.x' 'pharo12.x' 'pharo13.x') 
+		for: #('pharo9.x' 'pharo10.x' 'pharo11.x' 'pharo12.x' 'pharo13.x' 'pharo14.x') 
 		do:[
 			spec
 				package: 'Seaside-Pharo90-REST-Core';

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedHeader..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedHeader..st
@@ -1,0 +1,4 @@
+headers
+addAllowedHeader: aString
+
+	self allowedHeaders add: aString

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedHeadersTo..st
@@ -1,9 +1,9 @@
 handling
-addAllowedMethodsHeadersTo: aResponse
+addAllowedHeadersTo: aResponse
 
-	self allowedMethods ifNotEmpty: [ :allowed | 
+	self allowedHeaders ifNotEmpty: [ :allowed | 
 		aResponse
-			headerAt: 'Access-Control-Allow-Methods'
+			headerAt: 'Access-Control-Allow-Headers'
 			put: (String streamContents: [ :str | 
 					 allowed
 						 do: [ :allow | str nextPutAll: allow ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOrigin..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOrigin..st
@@ -1,4 +1,0 @@
-origins
-addAllowedOrigin: originUrlString
-
-	self allowedOrigins add: originUrlString asString

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeaderTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeaderTo..st
@@ -1,9 +1,7 @@
 handling
-addAllowedOriginHeadersTo: aResponse
+addAllowedOriginHeaderTo: aResponse
 
-	self allowedOrigins ifNotEmpty: [ :allowed | 
-		| allowedOrigin |
-		allowedOrigin := allowed first.
+	allowedOrigin ifNotNil: [
 		aResponse headerAt: 'Access-Control-Allow-Origin' put: allowedOrigin.
 		allowedOrigin = '*' ifFalse: [ 
 			aResponse headerAt: 'Vary' put: 'Origin' ] ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowedOriginHeadersTo..st
@@ -1,4 +1,4 @@
-headers
+handling
 addAllowedOriginHeadersTo: aResponse
 
 	self allowedOrigins ifNotEmpty: [ :allowed | 

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowsCredentialsHeaderTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowsCredentialsHeaderTo..st
@@ -1,0 +1,7 @@
+handling
+addAllowsCredentialsHeaderTo: aResponse
+
+	allowsCredentials ifNotNil: [
+		aResponse
+			headerAt: 'Access-Control-Allow-Credentials'
+			put: allowsCredentials greaseString ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowsCredentialsHeaderTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addAllowsCredentialsHeaderTo..st
@@ -1,7 +1,7 @@
 handling
 addAllowsCredentialsHeaderTo: aResponse
 
-	allowsCredentials ifNotNil: [
+	(allowsCredentials notNil and: [ allowsCredentials ]) ifTrue: [
 		aResponse
 			headerAt: 'Access-Control-Allow-Credentials'
 			put: allowsCredentials greaseString ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
@@ -1,7 +1,7 @@
 handling
 addCORSHeadersTo: response
 
-	self addAllowedOriginHeadersTo: response.
+	self addAllowedOriginHeaderTo: response.
 	self addAllowedMethodsHeadersTo: response.
 	self addExposedHeadersTo: response.
 	self addAllowedHeadersTo: response.

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addCORSHeadersTo..st
@@ -1,5 +1,9 @@
-headers
+handling
 addCORSHeadersTo: response
 
 	self addAllowedOriginHeadersTo: response.
-	self addAllowedMethodsHeadersTo: response
+	self addAllowedMethodsHeadersTo: response.
+	self addExposedHeadersTo: response.
+	self addAllowedHeadersTo: response.
+	self addMaxAgeHeaderTo: response.
+	self addAllowsCredentialsHeaderTo: response

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addExposedHeadersTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addExposedHeadersTo..st
@@ -1,4 +1,4 @@
-headers
+handling
 addExposedHeadersTo: aResponse
 
 	self exposedHeaders ifNotEmpty: [ :exposed | 

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/addMaxAgeHeaderTo..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/addMaxAgeHeaderTo..st
@@ -1,0 +1,7 @@
+handling
+addMaxAgeHeaderTo: aResponse
+
+	maxAge ifNotNil: [
+		aResponse
+			headerAt: 'Access-Control-Max-Age'
+			put: maxAge greaseString ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAllHeaders.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAllHeaders.st
@@ -1,4 +1,5 @@
 headers
 allowAllHeaders
 
+	self removeAllAllowedHeaders.
 	self addAllowedHeader: '*'

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAllHeaders.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAllHeaders.st
@@ -1,0 +1,4 @@
+headers
+allowAllHeaders
+
+	self addAllowedHeader: '*'

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAnyOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowAnyOrigin.st
@@ -1,4 +1,4 @@
 origins
 allowAnyOrigin
 
-	self addAllowedOrigin: '*'
+	self allowedOrigin: '*'

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin..st
@@ -1,0 +1,4 @@
+origins
+allowedOrigin: originUrlString
+
+	allowedOrigin := originUrlString greaseString

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin.st
@@ -1,4 +1,4 @@
 accessing
 allowedOrigin
 
-	^ allowedOrigin ifNil: [ allowedOrigin := OrderedCollection new ]
+	^ allowedOrigin

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigin.st
@@ -1,0 +1,4 @@
+accessing
+allowedOrigin
+
+	^ allowedOrigin ifNil: [ allowedOrigin := OrderedCollection new ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins..st
@@ -1,4 +1,0 @@
-accessing
-allowedOrigins: anObject
-
-	allowedOrigins := anObject

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowedOrigins.st
@@ -1,4 +1,0 @@
-accessing
-allowedOrigins 
-
-	^ allowedOrigins ifNil: [ allowedOrigins := OrderedCollection new ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsAnyOrigin.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsAnyOrigin.st
@@ -1,4 +1,4 @@
 testing
 allowsAnyOrigin
 
-	^ self allowedOrigins anySatisfy: [ :origin | origin = '*' ]
+	^ allowedOrigin = '*'

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/allowsCredentials..st
@@ -1,4 +1,4 @@
 accessing
-allowsCredentials: anObject
+allowsCredentials: aBoolean
 
-	allowsCredentials := anObject
+	allowsCredentials := aBoolean

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/denyAllOrigins.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/denyAllOrigins.st
@@ -1,4 +1,4 @@
 origins
 denyAllOrigins
 
-	self allowedOrigins removeAll
+	allowedOrigin := nil

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/exposedHeaders..st
@@ -1,4 +1,4 @@
 accessing
-exposedHeaders: anObject
+exposedHeaders: aCollection
 
-	exposedHeaders := anObject
+	exposedHeaders := aCollection

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/handleFiltered..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/handleFiltered..st
@@ -1,8 +1,6 @@
 handling
 handleFiltered: aRequestContext
 
-	"Pass on the aRequestContext to the next filter or handler. Subclasses might override this method to customize the request and response handling."
-
 	(self isPreflight: aRequestContext request)
 		ifTrue: [ self handleCORSPreflight: aRequestContext ]
 		ifFalse: [ 

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
@@ -1,9 +1,8 @@
-private
+initialization
 initialize 
 	
 	super initialize.
 	allowedOrigins := OrderedCollection new.
 	allowedHeaders := OrderedCollection new.
 	allowedMethods := OrderedCollection new.
-	exposedHeaders := OrderedCollection new.
-	allowsCredentials := false
+	exposedHeaders := OrderedCollection new

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/initialize.st
@@ -2,7 +2,6 @@ initialization
 initialize 
 	
 	super initialize.
-	allowedOrigins := OrderedCollection new.
 	allowedHeaders := OrderedCollection new.
 	allowedMethods := OrderedCollection new.
 	exposedHeaders := OrderedCollection new

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/maxAge..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/maxAge..st
@@ -1,0 +1,4 @@
+accessing
+maxAge: maxAgeInSeconds
+
+	maxAge := maxAgeInSeconds

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/maxAge.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/maxAge.st
@@ -1,0 +1,4 @@
+accessing
+maxAge
+
+	^ maxAge

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllAllowedHeaders.st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllAllowedHeaders.st
@@ -1,0 +1,4 @@
+headers
+removeAllAllowedHeaders
+
+	self allowedHeaders removeAll

--- a/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllowedOrigin..st
+++ b/repository/Seaside-Core.package/WACORSFilter.class/instance/removeAllowedOrigin..st
@@ -1,4 +1,0 @@
-origins
-removeAllowedOrigin: originUrlString
-
-	self allowedOrigins remove: originUrlString asString ifAbsent: [ ]

--- a/repository/Seaside-Core.package/WACORSFilter.class/properties.json
+++ b/repository/Seaside-Core.package/WACORSFilter.class/properties.json
@@ -6,12 +6,12 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"allowedOrigins",
 		"allowedMethods",
 		"allowedHeaders",
 		"exposedHeaders",
 		"allowsCredentials",
-		"maxAge"
+		"maxAge",
+		"allowedOrigin"
 	],
 	"name" : "WACORSFilter",
 	"type" : "normal"

--- a/repository/Seaside-Core.package/WACORSFilter.class/properties.json
+++ b/repository/Seaside-Core.package/WACORSFilter.class/properties.json
@@ -10,7 +10,8 @@
 		"allowedMethods",
 		"allowedHeaders",
 		"exposedHeaders",
-		"allowsCredentials"
+		"allowsCredentials",
+		"maxAge"
 	],
 	"name" : "WACORSFilter",
 	"type" : "normal"

--- a/repository/Seaside-Tests-Core.package/WACORSFilterPreflightRequestTest.class/instance/createRequest.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterPreflightRequestTest.class/instance/createRequest.st
@@ -1,0 +1,10 @@
+configuration
+createRequest
+	| headers request |
+	headers := Dictionary new.
+	headers at: 'origin' put: 'http://localhost:8080'.
+	request := WARequest
+		method: 'OPTIONS'
+		uri: '/corsfiltertest'.
+	request setHeaders: headers.
+	^ request

--- a/repository/Seaside-Tests-Core.package/WACORSFilterPreflightRequestTest.class/properties.json
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterPreflightRequestTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "WACORSFilterTest",
+	"category" : "Seaside-Tests-Core-Filter",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "WACORSFilterPreflightRequestTest",
+	"type" : "normal"
+}

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/createHandlers.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/createHandlers.st
@@ -1,0 +1,8 @@
+configuration
+createHandlers
+
+	| dispatcher root |
+	root := WADispatcher new.
+	dispatcher := root register: WADispatcher new at: 'root'.
+	application := dispatcher register: WAApplication new at: 'corsfiltertest'.
+	^ Array with: root with: dispatcher with: application

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/createRequest.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/createRequest.st
@@ -1,0 +1,8 @@
+configuration
+createRequest
+	| request headers |
+	request := WARequest new.
+	headers := Dictionary new.
+	headers at: 'origin' put: 'http://localhost:8080'.
+	request setHeaders: headers.
+	^ request

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowCredentials.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowCredentials.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestAllowCredentials
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter allowsCredentials: true.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Credentials') equals: 'true'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowCredentials2.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowCredentials2.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestAllowCredentials2
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter allowsCredentials: false.
+	response := self responseAfter: [ application handle: request ].
+	self assert: response headers isEmpty

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestAllowedHeaders
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter addAllowedHeader: 'Content-Type'.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Headers') equals: 'Content-Type'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders2.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders2.st
@@ -1,0 +1,12 @@
+tests
+testCORSRequestAllowedHeaders2
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter 
+		addAllowedHeader: 'Content-Type';
+		addAllowedHeader: 'X-Custom-Header'.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Headers') equals: 'Content-Type, X-Custom-Header'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders3.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedHeaders3.st
@@ -1,0 +1,12 @@
+tests
+testCORSRequestAllowedHeaders3
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter 
+		addAllowedHeader: 'Content-Type';
+		allowAllHeaders.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Headers') equals: '*'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedMethods.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedMethods.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestAllowedMethods
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter useExplicitMethods.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Methods') equals: 'GET, POST, HEAD'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedMethods2.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestAllowedMethods2.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestAllowedMethods2
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter addAllowedMethod: 'GET'.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Methods') equals: 'GET'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestEmpty.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestEmpty.st
@@ -1,0 +1,9 @@
+tests
+testCORSRequestEmpty
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	response := self responseAfter: [ application handle: request ].
+	self assert: response headers isEmpty.	

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestExposedHeaders.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestExposedHeaders.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestExposedHeaders
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter exposedHeaders: { 'Content-Type' . 'X-Custom-Header' }.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Expose-Headers') equals: 'Content-Type, X-Custom-Header'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestMaxAge.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestMaxAge.st
@@ -1,0 +1,10 @@
+tests
+testCORSRequestMaxAge
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter maxAge: 3600.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Max-Age') equals: '3600'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader.st
@@ -1,0 +1,11 @@
+tests
+testCORSRequestOriginsHeader
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter allowAnyOrigin.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Origin') equals: '*'.
+	self assert: (response headers at: 'Vary') equals: nil

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader.st
@@ -8,4 +8,5 @@ testCORSRequestOriginsHeader
 	filter allowAnyOrigin.
 	response := self responseAfter: [ application handle: request ].
 	self assert: (response headers at: 'Access-Control-Allow-Origin') equals: '*'.
-	self assert: (response headers at: 'Vary') equals: nil
+	self assert: (response headers at: 'Vary') equals: nil.
+	self assert: filter allowsAnyOrigin

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader2.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader2.st
@@ -1,0 +1,11 @@
+tests
+testCORSRequestOriginsHeader2
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter allowedOrigin: 'http://localhost:8080'.
+	response := self responseAfter: [ application handle: request ].
+	self assert: (response headers at: 'Access-Control-Allow-Origin') equals: 'http://localhost:8080'.
+	self assert: (response headers at: 'Vary') equals: 'Origin'

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader2.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader2.st
@@ -8,4 +8,5 @@ testCORSRequestOriginsHeader2
 	filter allowedOrigin: 'http://localhost:8080'.
 	response := self responseAfter: [ application handle: request ].
 	self assert: (response headers at: 'Access-Control-Allow-Origin') equals: 'http://localhost:8080'.
-	self assert: (response headers at: 'Vary') equals: 'Origin'
+	self assert: (response headers at: 'Vary') equals: 'Origin'.
+	self deny: filter allowsAnyOrigin

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader3.st
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/instance/testCORSRequestOriginsHeader3.st
@@ -1,0 +1,11 @@
+tests
+testCORSRequestOriginsHeader3
+
+	| response request filter |
+	request := self requestContext.
+	filter := WACORSFilter new.
+	application addFilterFirst: filter.
+	filter denyAllOrigins.
+	response := self responseAfter: [ application handle: request ].
+	self assert: response headers isEmpty.
+	self deny: filter allowsAnyOrigin

--- a/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/properties.json
+++ b/repository/Seaside-Tests-Core.package/WACORSFilterTest.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "",
+	"super" : "WAContextTest",
+	"category" : "Seaside-Tests-Core-Filter",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"application"
+	],
+	"name" : "WACORSFilterTest",
+	"type" : "normal"
+}

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSAllowedHeadersOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSAllowedHeadersOn..st
@@ -1,0 +1,20 @@
+rendering-configuration
+renderCORSAllowedHeadersOn: html
+
+	html heading
+		level2;
+		with: 'Currently allowed Headers.'.
+	self corsFilter allowedHeaders
+		ifEmpty: [ html text: 'None' ]
+		ifNotEmpty: [ :allowed | html unorderedList list: allowed ].
+
+	html form: [ 
+		html button
+			callback: [ 
+				self corsFilter allowAllHeaders ];
+			with: 'Allow all headers'.
+		html space.
+
+		html button
+			callback: [ self corsFilter removeAllAllowedHeaders ];
+			with: 'Remove all allowed headers' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterMaxAgeOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterMaxAgeOn..st
@@ -1,0 +1,28 @@
+rendering-configuration
+renderCORSFilterMaxAgeOn: html
+
+	| maxAgeValue |
+	html heading
+		level2;
+		with: 'Current Access-Control-Max-Age header:'.
+	html paragraph
+		id: 'maxage';
+		with:[
+			self corsFilter maxAge
+				ifNil: [ html text: 'None' ]
+				ifNotNil: [ :maxAge | html text: maxAge greaseString ] ].
+
+	html form: [ 
+		html textInput
+			placeholder: 'Enter maxAge (seconds)';
+			callback: [ :value | maxAgeValue := value greaseInteger ];
+			with: ''.
+		html space.
+		html button
+			callback: [ 
+				self corsFilter maxAge: maxAgeValue ];
+			with: 'Set Max-Age'.
+		html space.
+		html button
+			callback: [ self corsFilter maxAge: nil ];
+			with: 'Remove Max-Age' ]

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterOriginsOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderCORSFilterOriginsOn..st
@@ -7,9 +7,9 @@ renderCORSFilterOriginsOn: html
 	html paragraph
 		id: 'allowed-origins';
 		with:[
-			self corsFilter allowedOrigins
-				ifEmpty: [ html text: 'None' ]
-				ifNotEmpty: [ :origins | html unorderedList list: origins ] ].
+			self corsFilter allowedOrigin
+				ifNil: [ html text: 'None' ]
+				ifNotNil: [ :origin | html text: origin ] ].
 
 	html form: [ 
 		html button
@@ -21,7 +21,7 @@ renderCORSFilterOriginsOn: html
 		html button
 			callback: [ 
 				self corsFilter
-					addAllowedOrigin: (self baseUrl greaseString allButLast) ];
+					allowedOrigin: (self baseUrl greaseString allButLast) ];
 			with: 'Allow other origin'.
 		html space.
 

--- a/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestingOn..st
+++ b/repository/Seaside-Tests-Functional.package/WACORSFilterFunctionalTest.class/instance/renderTestingOn..st
@@ -9,6 +9,8 @@ renderTestingOn: html
 	html horizontalRule.
 	self renderCORSFilterOriginsOn: html.
 	self renderCORSFilterMethodsOn: html.
+	self renderCORSAllowedHeadersOn: html.
+	self renderCORSFilterMaxAgeOn: html.
 	html horizontalRule.
 	self renderTestsOn: html.
 	html horizontalRule.

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testButtonFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testButtonFunctionalTest.st
@@ -8,6 +8,7 @@ testButtonFunctionalTest
 	driver getKeyboard sendKeys: 'At the Seaside!'.
 	self assert: (driver findElementByTagName: 'td') getText equals: 'a text'.	
 	(driver findElementByCSSSelector: 'button[type=submit]') click.
+	self workaroundChromeDriver.
 	self assert: (driver findElementByTagName: 'td') getText equals: 'a textAt the Seaside!'.
 
 	"Push reset"

--- a/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCORSFilterFunctionalTest.st
+++ b/repository/Seaside-Tests-Parasol.package/WAWebDriverFunctionalTestCase.class/instance/testCORSFilterFunctionalTest.st
@@ -6,7 +6,7 @@ testCORSFilterFunctionalTest
 		self should: [ driver findElementByPartialLinkText: 'Register CORS Resource' ] raise: BPNoSuchElementException.
 
 		self assert: (driver findElementByID: 'allowed-origins') getText equals: 'None'.
-		(((driver findElementByID: 'get-requests') findElementsByTagName: 'button') detect: [ :button | button getText = 'Same Origin' ]) click.
+		(((driver findElementByID: 'get-requests') findElementsByTagName: 'button') detect: [ :button | button getText = 'Same Origin' ]) moveToElement; click.
 		self assert: self getCORSResultText equals: 'Success'.
 		
 		(((driver findElementByID: 'get-requests') findElementsByTagName: 'button') detect: [ :button | button getText = 'Cross Origin' ]) click.


### PR DESCRIPTION
Extend the `WACORSFilter` with support for the following CORS response headers:
- Access-Control-Allow-Credentials
- Access-Control-Max-Age
- Access-Control-Expose-Headers
- Access-Control-Allow-Headers

While adding tests, I also noticed the implementation for the Allow-Origin header is wrong. It should only ever allow a single value (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin). The implementation itself also only ever produced a single value (the first one in the collection), so I changed the code and adapted the method name; e.g.: #addAllowedOrigin: -> #allowOrigin: 