### PR TITLE
Replacing ConfigurationOf with BaselineOf; moving repository to github

### DIFF
--- a/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselineadaptors..st
+++ b/repository/BaselineOfSeaside3.package/BaselineOfSeaside3.class/instance/baselineadaptors..st
@@ -66,15 +66,14 @@ baselineadaptors: spec
 		for: #gemstone
 		do: [ 
 			spec
-				project: 'FastCGI Project'
+				baseline: 'FastCGI Project'
 					with: [ spec
-						className: 'ConfigurationOfGsFastCGI';
-						versionString: #stable;
-						loads: #('FastCGI');
-						repository: 'http://seaside.gemtalksystems.com/ss/MetacelloRepository' ];
+						className: 'BaselineOfFastCGI';
+						loads: #('Core');
+						repository: 'github://GsDevKit/FastCGI:master/repository' ];
 				baseline: 'GsApplicationTools'
 					with: [ spec
-						loads: 'Core';
+						loads: #('Core');
 						repository: 'github://GsDevKit/gsApplicationTools:master/repository' ];
 				baseline: 'Zinc Project'
 					with: [ spec


### PR DESCRIPTION
FastCGI gets pulled with Testing group.  It originally fetches and loads .mcz files into GemStone.  I have made a github repository from the previously loaded .mcz files and made changes to the baseline to match the Metacello load.