### PR TITLE
Fix websocket upgrade for firefox

### DIFF
--- a/repository/Seaside-Core.package/WARequest.class/instance/isWebSocketSetupRequest.st
+++ b/repository/Seaside-Core.package/WARequest.class/instance/isWebSocketSetupRequest.st
@@ -1,9 +1,9 @@
 testing
 isWebSocketSetupRequest
 	"Return true when request can be considered a valid WebSocket setup request"
-	
+
 	^ self isGet
 			and: [ (self headerAt: 'upgrade' ifAbsent: [ ^ false ]) asLowercase = 'websocket' 
-				and: [ (self headerAt: 'connection' ifAbsent: [ ^ false ]) asLowercase = 'upgrade' 
+				and: [ ((self headerAt: 'connection' ifAbsent: [ ^ false ]) asLowercase includesSubstring: 'upgrade')
 					and: [ (self headerAt: 'sec-websocket-version' ifAbsent: [ ^ false ]) = '13'
 						and: [ self headers includesKey: 'sec-websocket-key' ] ] ] ]


### PR DESCRIPTION
The header 'connection' has the value "keep-alive, Upgrade" when firefox sends the request. This change makes the upgrade request be recognized correctly in this case.

(Chrome only sends "Upgrade" when doing the request)

<img width="569" height="349" alt="image" src="https://github.com/user-attachments/assets/98478f36-161b-4423-b3a7-c4b07ca08fad" />
