### PR TITLE
Fix issue #1459 (Use #= instead of #== when comparing characters in WAHtmlCanvas>>#formatText:with: for compatibity in VAST)

### DIFF
--- a/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/formatText.with..st
+++ b/repository/Seaside-Canvas.package/WAHtmlCanvas.class/instance/formatText.with..st
@@ -4,7 +4,7 @@ formatText: aString with: collection
 	stream := aString readStream.
 	previousText := WriteStream on: String new.
 	[ stream atEnd ] whileFalse: [ | currentChar | 
-			(currentChar := stream next) == ${
+			(currentChar := stream next) = ${
 				ifTrue: [ 
 					| expression index | 
 					expression := stream upTo: $}.
@@ -13,7 +13,7 @@ formatText: aString with: collection
 					previousText := WriteStream on: String new.
 					self render: (collection at: index) ]
 				ifFalse: [
-					currentChar == $\
+					currentChar = $\
 						ifTrue: [ stream atEnd ifFalse: [ previousText nextPut: stream next ] ]
 						ifFalse: [ previousText nextPut: currentChar ] ] ].
 	self text: previousText contents.


### PR DESCRIPTION
Replaced `==` with `=` for comparing Characters such that it also works with UnicodeString's Grapheme instances in VAST