### PR TITLE
Adds a column to the seaside control panel in pharo

### DIFF
--- a/repository/Seaside-Pharo100-Tools-Spec2.package/WAPharoControlPanel.class/instance/initializeWidgets.st
+++ b/repository/Seaside-Pharo100-Tools-Spec2.package/WAPharoControlPanel.class/instance/initializeWidgets.st
@@ -13,19 +13,35 @@ initializeWidgets
 				width: 25;
 				yourself);
 		addColumn:
-			(SpStringTableColumn
+			((SpStringTableColumn
 				title: 'Kind'
-				evaluated: [ :adaptor | adaptor class ]);
+				evaluated: [ :adaptor | adaptor class ])
+				width: 180;
+				yourself);
 		addColumn:
-			(SpStringTableColumn
+			((SpStringTableColumn
 				title: 'Port'
-				evaluated: [ :adaptor | adaptor port ]);
+				evaluated: [ :adaptor | adaptor port ])
+				width: 50;
+				yourself
+				);
 		addColumn:
-			(SpStringTableColumn
+			((SpStringTableColumn
 				title: 'Status'
 				evaluated: [ :adaptor | 
 					adaptor isRunning
 						ifTrue: [ 'Running' ]
-						ifFalse: [ 'Stopped' ] ]);
+						ifFalse: [ 'Stopped' ] ])
+					width: 55;
+					yourself);
+		addColumn:
+			(SpStringTableColumn
+				title: 'Serve static files from:'
+				evaluated: [ :adaptor | 
+
+					(adaptor species = ZnZincStaticServerAdaptor)
+					 ifTrue: [ adaptor server delegate wwwRootDirectory ]
+					 ifFalse: [ 'Not serving static contents'] ]);			
+					
 		contextMenu: [ (self rootCommandsGroup / 'Table menu') beRoot asMenuPresenter ].
 	infos disable

--- a/repository/Seaside-Pharo100-Tools-Spec2.package/WAPharoControlPanel.class/instance/initializeWindow..st
+++ b/repository/Seaside-Pharo100-Tools-Spec2.package/WAPharoControlPanel.class/instance/initializeWindow..st
@@ -2,4 +2,4 @@ initialization
 initializeWindow: aWindowPresenter
 	aWindowPresenter
 		title: 'Seaside control panel';
-		initialExtent: 500 @ 400
+		initialExtent: 550 @ 400

--- a/repository/Seaside-Tests-Core.package/WATestServerAdaptor.class/instance/isStopped.st
+++ b/repository/Seaside-Tests-Core.package/WATestServerAdaptor.class/instance/isStopped.st
@@ -1,3 +1,4 @@
 testing
 isStopped
-	^ status = #stopped
+
+	^ status isNil or: [ status = #stopped ]

--- a/repository/Seaside-Tests-Core.package/monticello.meta/categories.st
+++ b/repository/Seaside-Tests-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-self packageOrganizer ensurePackage: #'Seaside-Tests-Core' withTags: #('Backtracking' 'Cache' 'Callbacks' 'Configuration' 'Document' 'HTTP' 'Libraries' 'Rendering' 'RequestHandling' 'Server' 'Utilities')!
+self packageOrganizer ensurePackage: #'Seaside-Tests-Core' withTags: #(#Backtracking #Cache #Callbacks #Configuration #Document #HTTP #Libraries #Rendering #RequestHandling #Server #Utilities)!


### PR DESCRIPTION
- Extra column shows the path of the folder used to serve static files.
- Updates window and column sizes
- Updates isStopped in the WATestServerAdaptor, status is nil initially  so it can't be removed from the panel using the menu.
<img width="403" height="116" alt="image" src="https://github.com/user-attachments/assets/cf9d95d7-ca38-483b-9eea-757bc200e234" />
