### PR TITLE
Fix `JSConversionTest >> #testDateAndTime` in GemStone 3.7.5.

### DIFF
--- a/repository/Javascript-Core.package/DateAndTime.extension/instance/javascriptOn..st
+++ b/repository/Javascript-Core.package/DateAndTime.extension/instance/javascriptOn..st
@@ -8,4 +8,4 @@ javascriptOn: aRenderer
 				argument: self dayOfMonth;
 				argument: self hour;
 				argument: self minute;
-				argument: self second ]
+				argument: self second asInteger ]


### PR DESCRIPTION
Ensure seconds is rendered as an integer.

DateAndTime instances in GemStone/S 3.7.5 will include fractional results for #second. Pharo and prior versions of GemStone/S return integer values.

This change fixes `JSConversionTest >> #testDateAndTime` in GemStone 3.7.5.