### PR TITLE
display correct uptime on the status/image tab for Squeak

### DIFF
--- a/repository/Seaside-Squeak-Tools-Web.package/WAImageStatus.class/instance/renderValuesOn..st
+++ b/repository/Seaside-Squeak-Tools-Web.package/WAImageStatus.class/instance/renderValuesOn..st
@@ -1,9 +1,7 @@
 rendering
 renderValuesOn: html
-	| upTime |
-	upTime := Duration milliseconds: Time millisecondClockValue.
 	
-	self renderLabel: 'Uptime' value: (self printDuration: upTime) on: html.
+	self renderLabel: 'Uptime' value: (self printDuration: self upTime) on: html.
 	self renderLabel: 'Version' value: Smalltalk version on: html.
 	self renderLabel: 'Image Path' value: (self image getSystemAttribute: 1) on: html.
 	self


### PR DESCRIPTION
Spotted dumb-typo error on the Squeak image status tab; the uptime was being calculated as the time since epoch. Especially daft since the WAImageStatus class already has a proper calculation.
Single method fix in Squeak specific package.