### PR TITLE
#1500 delegates session refresh to the session object

### DIFF
--- a/repository/Seaside-Session.package/WASession.class/instance/touch.st
+++ b/repository/Seaside-Session.package/WASession.class/instance/touch.st
@@ -1,0 +1,4 @@
+accessing
+touch 
+
+	self application cache at: self key ifAbsent: [  ]

--- a/repository/Seaside-WebSocket-Core.package/WAWebSocket.class/instance/touchSession.st
+++ b/repository/Seaside-WebSocket-Core.package/WAWebSocket.class/instance/touchSession.st
@@ -2,5 +2,4 @@ private
 touchSession
 	"Prevent session expiry."
 
-	session ifNotNil: [ :s | 
-		s application cache at: s key ifAbsent: [ ] ]
+	session ifNotNil: [ :aSession | aSession touch	 ]


### PR DESCRIPTION
Small PR to delegate session refresh from a web socket to the session itself. The changes keep the current implementation logic but allow more complex session refresh code to be modified in subclases of WASession.