### PR TITLE
Remove Pharo 8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-13, Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, GemStone64-3.7.4.3, GemStone64-3.6.8 ]
+        smalltalk: [ Pharo64-13, Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, GemStone64-3.7.4.3, GemStone64-3.6.8 ]
         experimental: [ false ]
         include:
           - smalltalk: Pharo64-14


### PR DESCRIPTION
The Pharo CI build currently always fails because the Pharo 8 images can no longer be downloaded using zeroconf.

For example https://github.com/SeasideSt/Seaside/actions/runs/28777377024/job/85324453348?pr=1532

```
Downloading Pharo64-8.0 image...
curl: (22) The requested URL returned error: 404
curl failed to download get.pharo.org/64/80 to '/home/runner/.smalltalkCI/_cache/Pharo64-8.0/zeroconfig'.
Error: Process completed with exit code 1.
```
The following URLs currently always 404.

https://get.pharo.org/64/80
https://get.pharo.org/32/80

Pharo 8 support is in the archive
https://github.com/pharo-project/pharo-zeroconf/blob/master/generated/archive/80/index.html