### PR TITLE
Add structured syntax suffix support to WAMimeType

### DIFF
--- a/repository/Seaside-Core.package/WAMimeType.class/instance/isBinary.st
+++ b/repository/Seaside-Core.package/WAMimeType.class/instance/isBinary.st
@@ -1,13 +1,16 @@
 testing
 isBinary
 	"answers whether the contents of a document of the receiving mime type are binary"
-	self main = 'text' ifTrue: [ ^ false ].
-	self main = 'application'
-		ifTrue: [
-			"application/json is text"
-			(#('json' 'x-www-form-urlencoded') includes: self sub) ifTrue: [ ^ false ] ].
-	GRPlatform subStringsIn: self sub splitBy: $+ do: [ :each |
-		"application/(x-)javascript and application/xml are text"
-		(#('x-javascript' 'javascript' 'xml') includes: each)
-			ifTrue: [ ^ false ] ].
-	^ true
+	| syntax |
+
+	self main = 'text' ifTrue: [^false].
+
+	syntax := self syntax.
+
+	(self main = 'application' and: [syntax = 'json'])
+		ifTrue: [ "application/json and application/*+json are text" ^false].
+
+	(#('x-javascript' 'javascript' 'xml') includes: syntax)
+		ifTrue: [ "*/(x-)javascript and */xml are text" ^false].
+
+	^true

--- a/repository/Seaside-Core.package/WAMimeType.class/instance/isJson.st
+++ b/repository/Seaside-Core.package/WAMimeType.class/instance/isJson.st
@@ -1,0 +1,7 @@
+testing
+isJson
+	"Answers whether the receiving mime type is JSON."
+	
+	self main = 'application' ifFalse: [^false].
+	
+	^self syntax = 'json'

--- a/repository/Seaside-Core.package/WAMimeType.class/instance/subName.st
+++ b/repository/Seaside-Core.package/WAMimeType.class/instance/subName.st
@@ -1,0 +1,10 @@
+accessing
+subName
+	"Answers the component preceding the final '+' in the sub(type).
+	Answers nil when the sub(type) does not contain a '+'."
+
+	| index |
+
+	index := self subSeparatorIndex.
+
+	^index = 0 ifTrue: [nil] ifFalse: [self sub copyFrom: 1 to: index - 1]

--- a/repository/Seaside-Core.package/WAMimeType.class/instance/subSeparatorIndex.st
+++ b/repository/Seaside-Core.package/WAMimeType.class/instance/subSeparatorIndex.st
@@ -1,0 +1,5 @@
+private
+subSeparatorIndex
+	"Aswers the index of the last '+' separator in the sub(type), or 0 if not present."
+	
+    ^self sub lastIndexOf: $+

--- a/repository/Seaside-Core.package/WAMimeType.class/instance/syntax.st
+++ b/repository/Seaside-Core.package/WAMimeType.class/instance/syntax.st
@@ -1,0 +1,10 @@
+accessing
+syntax
+	"Answers the structured syntax suffix identified by the final '+' in
+	the sub(type) or, when absent, the sub(type) itself."
+
+	| index |
+
+	index := self subSeparatorIndex.
+
+	^index = 0 ifTrue: [self sub] ifFalse: [self sub copyFrom: index + 1 to: self sub size]

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testJson.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testJson.st
@@ -1,6 +1,22 @@
 tests
 testJson
-	"regression test for
-	http://code.google.com/p/seaside/issues/detail?id=759"
+	"Test JSON MIME type detection for both simple and structured syntax formats"
+	
+	"Standard JSON"
+	self assert: (WAMimeType fromString: 'application/json') isJson.
+	
+	"Non-application types"
+	self deny: (WAMimeType fromString: 'text/json') isJson.
+	
+	"Structured syntax with JSON suffix (RFC 6839)"
+	self assert: (WAMimeType fromString: 'application/ld+json') isJson.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') isJson.
+	
+	"Non-JSON types"
+	self deny: (WAMimeType fromString: 'application/xml') isJson.
+	self deny: (WAMimeType fromString: 'application/ld+xml') isJson.
+	self deny: (WAMimeType fromString: 'image/json') isJson.
+	
+	"regression test for http://code.google.com/p/seaside/issues/detail?id=759"
 	self deny: (WAMimeType fromString: 'text/json') isBinary.
 	self deny: (WAMimeType fromString: 'application/json') isBinary

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubName.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubName.st
@@ -6,8 +6,8 @@ testSubName
 	self assert: (WAMimeType fromString: 'application/json') subName isNil.
 	
 	"With separator"
-	self assert: (WAMimeType fromString: 'application/ld+json') subName = 'ld'.
-	self assert: (WAMimeType fromString: 'application/vnd.api+json') subName = 'vnd.api'.
+	self assert: (WAMimeType fromString: 'application/ld+json') subName equals: 'ld'.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') subName equals: 'vnd.api'.
 	
 	"With multiple separators, uses part before last +"
-	self assert: (WAMimeType fromString: 'application/foo+bar+json') subName = 'foo+bar'
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') subName equals: 'foo+bar'

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubName.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubName.st
@@ -1,0 +1,13 @@
+tests
+testSubName
+	"Test extraction of subtype name before '+' separator"
+	
+	"Without separator, should return nil"
+	self assert: (WAMimeType fromString: 'application/json') subName isNil.
+	
+	"With separator"
+	self assert: (WAMimeType fromString: 'application/ld+json') subName = 'ld'.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') subName = 'vnd.api'.
+	
+	"With multiple separators, uses part before last +"
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') subName = 'foo+bar'

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubSeparatorIndex.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubSeparatorIndex.st
@@ -1,0 +1,13 @@
+tests
+testSubSeparatorIndex
+	"Test the index of the '+' separator in subtypes"
+	
+	"Simple subtype without separator"
+	self assert: (WAMimeType fromString: 'application/json') subSeparatorIndex = 0.
+	
+	"Subtype with '+' separator"
+	self assert: (WAMimeType fromString: 'application/ld+json') subSeparatorIndex = 3.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') subSeparatorIndex = 14.
+	
+	"Multiple '+' separators - should return last one"
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') subSeparatorIndex = 13

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubSeparatorIndex.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSubSeparatorIndex.st
@@ -3,11 +3,11 @@ testSubSeparatorIndex
 	"Test the index of the '+' separator in subtypes"
 	
 	"Simple subtype without separator"
-	self assert: (WAMimeType fromString: 'application/json') subSeparatorIndex = 0.
+	self assert: (WAMimeType fromString: 'application/json') subSeparatorIndex equals: 0.
 	
 	"Subtype with '+' separator"
-	self assert: (WAMimeType fromString: 'application/ld+json') subSeparatorIndex = 3.
-	self assert: (WAMimeType fromString: 'application/vnd.api+json') subSeparatorIndex = 14.
+	self assert: (WAMimeType fromString: 'application/ld+json') subSeparatorIndex equals: 3.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') subSeparatorIndex equals: 8.
 	
 	"Multiple '+' separators - should return last one"
-	self assert: (WAMimeType fromString: 'application/foo+bar+json') subSeparatorIndex = 13
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') subSeparatorIndex equals: 8

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSyntax.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSyntax.st
@@ -3,12 +3,12 @@ testSyntax
 	"Test extraction of syntax suffix after '+' separator"
 	
 	"Without separator, returns full subtype"
-	self assert: (WAMimeType fromString: 'application/json') syntax = 'json'.
-	self assert: (WAMimeType fromString: 'text/plain') syntax = 'plain'.
+	self assert: (WAMimeType fromString: 'application/json') syntax equals: 'json'.
+	self assert: (WAMimeType fromString: 'text/plain') syntax equals: 'plain'.
 	
 	"With separator"
-	self assert: (WAMimeType fromString: 'application/ld+json') syntax = 'json'.
-	self assert: (WAMimeType fromString: 'application/vnd.api+json') syntax = 'json'.
+	self assert: (WAMimeType fromString: 'application/ld+json') syntax equals: 'json'.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') syntax equals: 'json'.
 	
 	"With multiple separators, uses part after last +"
-	self assert: (WAMimeType fromString: 'application/foo+bar+json') syntax = 'json'
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') syntax equals: 'json'

--- a/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSyntax.st
+++ b/repository/Seaside-Tests-Core.package/WAMimeTypeTest.class/instance/testSyntax.st
@@ -1,0 +1,14 @@
+tests
+testSyntax
+	"Test extraction of syntax suffix after '+' separator"
+	
+	"Without separator, returns full subtype"
+	self assert: (WAMimeType fromString: 'application/json') syntax = 'json'.
+	self assert: (WAMimeType fromString: 'text/plain') syntax = 'plain'.
+	
+	"With separator"
+	self assert: (WAMimeType fromString: 'application/ld+json') syntax = 'json'.
+	self assert: (WAMimeType fromString: 'application/vnd.api+json') syntax = 'json'.
+	
+	"With multiple separators, uses part after last +"
+	self assert: (WAMimeType fromString: 'application/foo+bar+json') syntax = 'json'


### PR DESCRIPTION
Add support for structured syntax suffixes (e.g. application/hal+json and application/atom+xml) to WAMimeType.
Introduces:

- #syntax
- #subName

and updates #isBinary to recognize JSON-based media types via their structured syntax suffix.
Examples:

- application/json
- application/hal+json
- application/problem+json
- application/xml
- application/atom+xml